### PR TITLE
network: detect Wi-Fi interface via CoreWLAN instead of en0 name

### DIFF
--- a/Sources/DataCollection/Modules/NetworkModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/NetworkModuleProcessor.swift
@@ -196,15 +196,21 @@ public class NetworkModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         let activeConnectionInfo = try await getActiveConnectionInfo()
         let activeInterfaceName = activeConnectionInfo["interface"] as? String
         let gateway = activeConnectionInfo["gateway"] as? String
-        
+
+        // Determine which interfaces are Wi-Fi by asking CoreWLAN directly.
+        // Interface naming is NOT a reliable signal: en0 is Wi-Fi on laptops but
+        // Ethernet on desktop Macs (iMac/Mac mini/Studio), where Wi-Fi is en1+.
+        // CoreWLAN enumerates Wi-Fi hardware without needing Location Services.
+        let wifiInterfaceNames = Set(CWWiFiClient.shared().interfaces()?.compactMap { $0.interfaceName } ?? [])
+
         // Map RawNetworkInterface to global NetworkInterface
         let interfaces = filteredRawInterfaces.map { raw -> NetworkInterface in
             // Determine if this is the active interface
             let isActive = raw.name == activeInterfaceName
-            
-            // Determine interface type - en0 is typically WiFi on Mac
+
+            // Determine interface type from CoreWLAN, not the interface name
             let type: NetworkInterfaceType
-            if raw.name == "en0" {
+            if wifiInterfaceNames.contains(raw.name) {
                 type = .wifi
             } else if raw.name.hasPrefix("en") {
                 type = .ethernet
@@ -251,7 +257,7 @@ public class NetworkModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             // Find the first IPv4 address for the active interface
             let activeIfaceData = filteredRawInterfaces.first { $0.name == physicalIface && $0.address?.contains(".") == true }
             
-            let connType = physicalIface == "en0" ? "WiFi" : "Ethernet"
+            let connType = wifiInterfaceNames.contains(physicalIface) ? "WiFi" : "Ethernet"
             
             activeConnection = ActiveConnection(
                 interface: physicalIface,

--- a/Sources/DataCollection/Modules/NetworkModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/NetworkModuleProcessor.swift
@@ -208,15 +208,10 @@ public class NetworkModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             // Determine if this is the active interface
             let isActive = raw.name == activeInterfaceName
 
-            // Determine interface type from CoreWLAN, not the interface name
-            let type: NetworkInterfaceType
-            if wifiInterfaceNames.contains(raw.name) {
-                type = .wifi
-            } else if raw.name.hasPrefix("en") {
-                type = .ethernet
-            } else {
-                type = .other
-            }
+            // Determine interface type from CoreWLAN, not the interface name.
+            // filteredRawInterfaces is already restricted to en* above, so any
+            // interface that is not Wi-Fi here is Ethernet.
+            let type: NetworkInterfaceType = wifiInterfaceNames.contains(raw.name) ? .wifi : .ethernet
             
             var addresses: [NetworkAddress] = []
             if let addr = raw.address {


### PR DESCRIPTION
## Problem

Ethernet and Wi-Fi addresses appear swapped on the dashboard for desktop Macs. The Network module typed interfaces purely by name:

```swift
if raw.name == "en0" { type = .wifi }
else if raw.name.hasPrefix("en") { type = .ethernet }
```

`en0 == Wi-Fi` only holds for laptops. On desktop Macs (iMac, Mac mini, Mac Studio) built-in Ethernet is `en0` and Wi-Fi is `en1+`, so lab machines reported their interfaces backwards: the Ethernet card showed the Wi-Fi IP (wireless subnet) and the Wi-Fi card showed the wired IP, with the SSID borrowed onto the wrong card.

## Fix

Interface type now comes from CoreWLAN — `CWWiFiClient.shared().interfaces()` enumerates the real Wi-Fi hardware (no Location Services required). Interfaces in that set are `.wifi`, other `en*` are `.ethernet`. `activeConnection.connectionType` uses the same signal.

## Testing

`swift build` succeeds. Takes effect once devices rebuild/redeploy and re-run the `network` module.