### PR TITLE
ci: fix macOS Client build (SQLite Expression collision + missing ModuleVersions)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,43 @@ jobs:
           }
           EOF
 
+      - name: Generate ModuleVersions.swift
+        run: |
+          mkdir -p Sources/Generated
+          FALLBACK_VERSION="$(date -u +%Y.%m.%d.%H%M)"
+          MODULES="applications|Sources/DataCollection/Modules/ApplicationsModuleProcessor.swift Sources/Models/Modules/AnalyticsModels.swift
+          hardware|Sources/DataCollection/Modules/HardwareModuleProcessor.swift Sources/Models/Modules/HardwareModels.swift
+          identity|Sources/DataCollection/Modules/IdentityModuleProcessor.swift Sources/Models/Modules/IdentityModels.swift
+          installs|Sources/DataCollection/Modules/InstallsModuleProcessor.swift Sources/Models/Modules/InstallsModels.swift
+          inventory|Sources/DataCollection/Modules/InventoryModuleProcessor.swift Sources/Models/Modules/InventoryModels.swift
+          management|Sources/DataCollection/Modules/ManagementModuleProcessor.swift Sources/Models/Modules/ManagementModels.swift
+          network|Sources/DataCollection/Modules/NetworkModuleProcessor.swift Sources/Models/Modules/NetworkModels.swift
+          peripherals|Sources/DataCollection/Modules/PeripheralsModuleProcessor.swift Sources/Models/Modules/PeripheralsModels.swift
+          security|Sources/DataCollection/Modules/SecurityModuleProcessor.swift Sources/Models/Modules/SecurityModels.swift
+          system|Sources/DataCollection/Modules/SystemModuleProcessor.swift Sources/Models/Modules/SystemModels.swift"
+          {
+            echo "import Foundation"
+            echo ""
+            echo "/// Per-module versions derived from git commit history"
+            echo "/// Format: YYYY.MM.DD.HHMM — reflects last change to each module's source files"
+            echo "/// This file is auto-generated at build time — do not edit manually"
+            echo "public enum ModuleVersions {"
+            echo "    public static func version(for moduleId: String) -> String {"
+            echo "        switch moduleId.lowercased() {"
+            while IFS='|' read -r module_id files; do
+              [ -z "$module_id" ] && continue
+              module_version="$FALLBACK_VERSION"
+              git_date=$(git log --format=%cd --date=format:%Y.%m.%d.%H%M -1 -- $files 2>/dev/null)
+              [ -n "$git_date" ] && module_version="$git_date"
+              echo "        case \"$module_id\": return \"$module_version\""
+            done <<< "$MODULES"
+            echo "        default: return \"0.0.0.0000\""
+            echo "        }"
+            echo "    }"
+            echo "}"
+          } > Sources/Generated/ModuleVersions.swift
+          cat Sources/Generated/ModuleVersions.swift
+
       - name: Build Swift package
         run: |
           CONFIGURATION="${{ github.event.inputs.configuration || 'release' }}"

--- a/Sources/DataCollection/Services/ApplicationUsageService.swift
+++ b/Sources/DataCollection/Services/ApplicationUsageService.swift
@@ -1,6 +1,11 @@
 import Foundation
 import SQLite
 
+/// SQLite.swift's `Expression` collides with `Foundation.Expression` on recent
+/// SDKs, making bare `Expression<...>` ambiguous. Alias to the SQLite type so
+/// the column declarations below stay unambiguous.
+private typealias Expression<Datatype> = SQLite.Expression<Datatype>
+
 // MARK: - Application Usage Models
 
 /// Snapshot of application usage data - matches Windows ApplicationUsageSnapshot

--- a/Sources/Watcher/Database/AppUsageDatabase.swift
+++ b/Sources/Watcher/Database/AppUsageDatabase.swift
@@ -1,6 +1,11 @@
 import Foundation
 import SQLite
 
+/// SQLite.swift's `Expression` collides with `Foundation.Expression` on recent
+/// SDKs, making bare `Expression<...>` ambiguous. Alias to the SQLite type so
+/// the column declarations below stay unambiguous.
+private typealias Expression<Datatype> = SQLite.Expression<Datatype>
+
 /// SQLite database for persisting application usage sessions
 /// Location: /Library/Managed Reports/appusage.sqlite
 public final class AppUsageDatabase: @unchecked Sendable {


### PR DESCRIPTION
## Problem

The "Build macOS Client" CI check has been **failing on `main` since the appusage feature landed** (2026-05-12). Two independent pre-existing breaks:

1. **SQLite/Foundation `Expression` collision** — recent SDKs expose `Foundation.Expression`, which clashes with SQLite.swift's `Expression`. Bare `Expression<...>` column declarations in `AppUsageDatabase.swift` and `ApplicationUsageService.swift` become ambiguous.
2. **Missing `ModuleVersions.swift`** — `build.yml` claims to replicate `build.sh` but only generated `AppVersion.swift`. `Sources/Generated/` is gitignored, so a fresh CI checkout had no `ModuleVersions.swift` → `cannot find 'ModuleVersions' in scope`.

## Fix

1. File-private `typealias Expression<Datatype> = SQLite.Expression<Datatype>` in both files that declare typed columns — the module-qualified RHS is unambiguous and existing `Expression<...>` usage resolves through it unchanged.
2. New "Generate ModuleVersions.swift" workflow step mirroring `build.sh`: derives per-module versions from git history before the Swift build. Bash 3.2 compatible.

## Scope

Unrelated to the network interface-type fix (#3) — pre-existing CI debt. #3 stays red until this merges.

## Testing

`swift build` succeeds locally; the workflow generation logic was run locally and produces valid Swift with real per-module versions.
