### PR TITLE
fix: bound osquery + module collection with timeouts to unstick management

### DIFF
--- a/Sources/Core/Configuration/ConfigurationManager.swift
+++ b/Sources/Core/Configuration/ConfigurationManager.swift
@@ -145,9 +145,12 @@ public class ConfigurationManager {
             "REPORTMATE_DEVICE_ID": "DeviceId",
             "REPORTMATE_PASSPHRASE": "Passphrase",
             "REPORTMATE_COLLECTION_INTERVAL": "CollectionInterval",
-            "REPORTMATE_LOG_LEVEL": "LogLevel"
+            "REPORTMATE_LOG_LEVEL": "LogLevel",
+            "REPORTMATE_QUERY_TIMEOUT": "QueryTimeoutSeconds",
+            "REPORTMATE_EXTENSION_QUERY_TIMEOUT": "ExtensionQueryTimeoutSeconds",
+            "REPORTMATE_MODULE_TIMEOUT": "ModuleTimeoutSeconds"
         ]
-        
+
         for (envKey, configKey) in envMappings {
             if let value = environment[envKey] {
                 // Convert string values to appropriate types
@@ -155,6 +158,10 @@ public class ConfigurationManager {
                 case "CollectionInterval":
                     if let intValue = Int(value) {
                         config[configKey] = intValue
+                    }
+                case "QueryTimeoutSeconds", "ExtensionQueryTimeoutSeconds", "ModuleTimeoutSeconds":
+                    if let doubleValue = Double(value) {
+                        config[configKey] = doubleValue
                     }
                 case "EnabledModules":
                     config[configKey] = value.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
@@ -224,6 +231,22 @@ public struct ReportMateConfiguration {
     public var validateSSL: Bool = true
     public var timeout: Int = 300 // 5 minutes
 
+    /// Per-query timeout for built-in osquery tables. Kills the osqueryi process
+    /// if it does not return within this bound, so a single misbehaving table
+    /// cannot block the rest of a module's collection.
+    public var queryTimeoutSeconds: Double = 30
+
+    /// Per-query timeout for macadmins extension tables. Higher than the built-in
+    /// bound because the extension path includes a 7s startup sleep plus the
+    /// extension's own registration time. Tables that do online I/O (e.g.
+    /// sofa_unpatched_cves fetching the SOFA feed) are the usual offenders.
+    public var extensionQueryTimeoutSeconds: Double = 60
+
+    /// Per-module wall-clock timeout. Defensive layer in case the sum of a
+    /// module's queries exceeds a useful budget; the module returns whatever
+    /// partial data it has and the runner moves on to the next module.
+    public var moduleTimeoutSeconds: Double = 120
+
     /// Controls whether deep storage directory analysis runs on each collection cycle
     public var storageMode: StorageMode = .auto
 
@@ -241,6 +264,12 @@ public struct ReportMateConfiguration {
         if let useAltSystemInfo = other["UseAltSystemInfo"] as? Bool { self.useAltSystemInfo = useAltSystemInfo }
         if let validateSSL = other["ValidateSSL"] as? Bool { self.validateSSL = validateSSL }
         if let timeout = other["Timeout"] as? Int { self.timeout = timeout }
+        if let queryTimeout = other["QueryTimeoutSeconds"] as? Double { self.queryTimeoutSeconds = queryTimeout }
+        else if let queryTimeoutInt = other["QueryTimeoutSeconds"] as? Int { self.queryTimeoutSeconds = Double(queryTimeoutInt) }
+        if let extQueryTimeout = other["ExtensionQueryTimeoutSeconds"] as? Double { self.extensionQueryTimeoutSeconds = extQueryTimeout }
+        else if let extQueryTimeoutInt = other["ExtensionQueryTimeoutSeconds"] as? Int { self.extensionQueryTimeoutSeconds = Double(extQueryTimeoutInt) }
+        if let moduleTimeout = other["ModuleTimeoutSeconds"] as? Double { self.moduleTimeoutSeconds = moduleTimeout }
+        else if let moduleTimeoutInt = other["ModuleTimeoutSeconds"] as? Int { self.moduleTimeoutSeconds = Double(moduleTimeoutInt) }
         if let storageModeStr = other["StorageMode"] as? String,
            let mode = StorageMode(rawValue: storageModeStr) { self.storageMode = mode }
     }

--- a/Sources/DataCollection/DataCollectionService.swift
+++ b/Sources/DataCollection/DataCollectionService.swift
@@ -28,7 +28,8 @@ public class DataCollectionService {
     /// Collect data from all enabled modules
     public func collectAllModules() async throws -> [String: Any] {
         var moduleResults: [String: ModuleData] = [:]
-        
+        let timeout = configuration.moduleTimeoutSeconds
+
         // Execute data collection concurrently across all enabled modules
         await withTaskGroup(of: (String, ModuleData?).self) { group in
             for moduleId in configuration.enabledModules {
@@ -36,54 +37,54 @@ public class DataCollectionService {
                     print("Warning: No processor found for module '\(moduleId)'")
                     continue
                 }
-                
+
                 group.addTask { @Sendable [processor] in
-                    do {
-                        let data = try await processor.collectData()
-                        return (moduleId, data)
-                    } catch {
-                        print("Error collecting data from module '\(moduleId)': \(error)")
-                        return (moduleId, nil)
-                    }
+                    let data = await Self.collectModuleWithTimeout(
+                        moduleId: moduleId,
+                        processor: processor,
+                        timeoutSeconds: timeout
+                    )
+                    return (moduleId, data)
                 }
             }
-            
+
             for await (moduleId, moduleData) in group {
                 if let moduleData = moduleData {
                     moduleResults[moduleId] = moduleData
                 }
             }
         }
-        
+
         // Create device identification
         let deviceInfo = try await collectDeviceInfo()
-        
+
         // Build unified payload structure matching Windows client format
         return buildUnifiedPayload(deviceInfo: deviceInfo, moduleResults: moduleResults)
     }
-    
+
     /// Collect data from specific modules
     public func collectSpecificModules(_ moduleIds: [String]) async throws -> [String: Any] {
         var moduleResults: [String: ModuleData] = [:]
-        
+        let timeout = configuration.moduleTimeoutSeconds
+
         for moduleId in moduleIds {
             guard let processor = moduleProcessors[moduleId] else {
                 print("Warning: Module '\(moduleId)' not found, skipping...")
                 continue
             }
-            
-            do {
-                let moduleData = try await processor.collectData()
+
+            if let moduleData = await Self.collectModuleWithTimeout(
+                moduleId: moduleId,
+                processor: processor,
+                timeoutSeconds: timeout
+            ) {
                 moduleResults[moduleId] = moduleData
-            } catch {
-                print("Warning: Failed to collect data from module '\(moduleId)': \(error.localizedDescription)")
-                // Continue with other modules instead of failing completely
             }
         }
-        
+
         // Create device identification
         let deviceInfo = try await collectDeviceInfo()
-        
+
         // Build unified payload structure matching Windows client format
         return buildUnifiedPayload(deviceInfo: deviceInfo, moduleResults: moduleResults)
     }
@@ -93,8 +94,50 @@ public class DataCollectionService {
         guard let processor = moduleProcessors[moduleId] else {
             throw DataCollectionError.moduleNotFound(moduleId)
         }
-        
-        return try await processor.collectData()
+
+        return await Self.collectModuleWithTimeout(
+            moduleId: moduleId,
+            processor: processor,
+            timeoutSeconds: configuration.moduleTimeoutSeconds
+        )
+    }
+
+    /// Race a module's collectData() against a wall-clock budget. Defensive
+    /// layer on top of the per-query timeout in OSQueryService: even if the
+    /// individual queries respect their bounds, the sum of bash fallbacks,
+    /// I/O, and processing must still fit in a useful window. On timeout,
+    /// the module is skipped — every other module still transmits.
+    private static func collectModuleWithTimeout(
+        moduleId: String,
+        processor: ModuleProcessor,
+        timeoutSeconds: Double
+    ) async -> ModuleData? {
+        let start = Date()
+        do {
+            let result: ModuleData? = try await withThrowingTaskGroup(of: ModuleData?.self) { group in
+                group.addTask { @Sendable [processor] in
+                    return try await processor.collectData()
+                }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                    throw ModuleTimeoutError.timedOut(moduleId, timeoutSeconds)
+                }
+                defer { group.cancelAll() }
+                let first = try await group.next()
+                return first ?? nil
+            }
+            let elapsed = Date().timeIntervalSince(start)
+            ConsoleFormatter.writeInfo("module \(moduleId) status=ok elapsed=\(String(format: "%.1fs", elapsed))")
+            return result
+        } catch let error as ModuleTimeoutError {
+            let elapsed = Date().timeIntervalSince(start)
+            ConsoleFormatter.writeWarning("module \(moduleId) status=timeout budget=\(String(format: "%.0fs", error.seconds)) elapsed=\(String(format: "%.1fs", elapsed)) -- skipping, other modules will still transmit")
+            return nil
+        } catch {
+            let elapsed = Date().timeIntervalSince(start)
+            ConsoleFormatter.writeWarning("module \(moduleId) status=failed elapsed=\(String(format: "%.1fs", elapsed)) error=\(error.localizedDescription)")
+            return nil
+        }
     }
     
     // MARK: - Private Methods
@@ -253,6 +296,16 @@ public class DataCollectionService {
 }
 
 // MARK: - Error Types
+
+enum ModuleTimeoutError: Error {
+    case timedOut(String, Double)
+
+    var seconds: Double {
+        switch self {
+        case .timedOut(_, let seconds): return seconds
+        }
+    }
+}
 
 public enum DataCollectionError: Error, LocalizedError {
     case moduleNotFound(String)

--- a/Sources/DataCollection/OSQueryService.swift
+++ b/Sources/DataCollection/OSQueryService.swift
@@ -150,196 +150,290 @@ public class OSQueryService {
     /// For extension tables, uses the --extension flag which starts extension as a child process
     /// The extension takes ~3 seconds to register, so for extension tables we use a two-phase approach
     /// Built-in table queries always use the fast path (no extension loading)
+    ///
+    /// Both code paths are wrapped in a hard timeout: if osqueryi does not return
+    /// within the configured budget, the child process is killed (SIGTERM, then
+    /// SIGKILL after a 2s grace period) and `OSQueryError.timeout` is thrown. This
+    /// prevents a single misbehaving table — most commonly extension tables that
+    /// do online I/O like `sofa_unpatched_cves` fetching the SOFA feed — from
+    /// blocking the rest of a module's collection indefinitely.
     public func executeQuery(_ query: String) async throws -> [[String: Any]] {
-        // Route built-in table queries to the fast path — no extension overhead
-        if extensionPath == nil || !Self.queryUsesExtensionTables(query) {
-            return try await executeSimpleQuery(query)
+        let useExtension = extensionPath != nil && Self.queryUsesExtensionTables(query)
+        let timeout = useExtension
+            ? configuration.extensionQueryTimeoutSeconds
+            : configuration.queryTimeoutSeconds
+
+        // Snapshot the values the detached query runner needs so the task
+        // closures don't capture `self` (avoids Swift 6 sending-closure data
+        // race diagnostics for this non-Sendable class).
+        let osqueryPath = self.osqueryPath
+        let extensionPath = self.extensionPath
+
+        return try await withThrowingTaskGroup(of: QueryRunResult.self) { group in
+            let processBox = ProcessBox()
+
+            group.addTask {
+                let rows: [[String: Any]]
+                if useExtension, let extensionPath = extensionPath {
+                    rows = try await Self.runExtensionQuery(
+                        query,
+                        osqueryPath: osqueryPath,
+                        extensionPath: extensionPath,
+                        processBox: processBox
+                    )
+                } else {
+                    rows = try await Self.runSimpleQuery(
+                        query,
+                        osqueryPath: osqueryPath,
+                        processBox: processBox
+                    )
+                }
+                return .completed(rows)
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                return .timedOut
+            }
+
+            defer { group.cancelAll() }
+
+            while let outcome = try await group.next() {
+                switch outcome {
+                case .completed(let rows):
+                    return rows
+                case .timedOut:
+                    processBox.terminate()
+                    // Grace period, then SIGKILL if still alive.
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    processBox.forceKill()
+                    throw OSQueryError.timeout(timeout)
+                }
+            }
+            return []
         }
-        
-        // Extension tables: use osqueryi's --extension flag with sleep delay
-        return try await executeQueryWithExtension(query)
+    }
+
+    /// Outcome of one query race participant.
+    /// `@unchecked Sendable` is sound here because each case payload is
+    /// produced inside a single Task and only read after that Task ends;
+    /// there is no concurrent mutation of the dictionary contents.
+    private enum QueryRunResult: @unchecked Sendable {
+        case completed([[String: Any]])
+        case timedOut
+    }
+
+    /// Sendable wrapper for the JSON rows crossing Task boundaries. Same
+    /// soundness argument as `QueryRunResult`: the rows are produced in one
+    /// Task, never shared concurrently.
+    private struct QueryRows: @unchecked Sendable {
+        let rows: [[String: Any]]
+    }
+
+    /// Shared handle to the running osqueryi/bash Process so the timeout watcher
+    /// can kill it from outside the running Task. Process itself is not Sendable
+    /// across Swift Concurrency boundaries; we wrap it in a small class with
+    /// just terminate/kill so the timeout path is self-contained.
+    private final class ProcessBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var process: Process?
+
+        func attach(_ process: Process) {
+            lock.lock(); defer { lock.unlock() }
+            self.process = process
+        }
+
+        func terminate() {
+            lock.lock(); defer { lock.unlock() }
+            guard let process = process, process.isRunning else { return }
+            process.terminate()
+        }
+
+        func forceKill() {
+            lock.lock(); defer { lock.unlock() }
+            guard let process = process, process.isRunning else { return }
+            kill(process.processIdentifier, SIGKILL)
+        }
     }
     
-    /// Execute a simple osquery query without extension support
-    private func executeSimpleQuery(_ query: String) async throws -> [[String: Any]] {
-        return try await withCheckedThrowingContinuation { continuation in
+    /// Execute a simple osquery query without extension support.
+    /// Runs on a detached Task so the blocking pipe reads release the cooperative
+    /// thread pool; on timeout, the parent will terminate the Process and the
+    /// pipe will EOF, unblocking the read here.
+    private static func runSimpleQuery(_ query: String, osqueryPath: String, processBox: ProcessBox) async throws -> [[String: Any]] {
+        let box = try await Task.detached(priority: .userInitiated) { () throws -> QueryRows in
             let task = Process()
             task.executableURL = URL(fileURLWithPath: osqueryPath)
             task.arguments = ["--json", query]
-            
+
             let outputPipe = Pipe()
             let errorPipe = Pipe()
             task.standardOutput = outputPipe
             task.standardError = errorPipe
-            
+
             do {
                 try task.run()
-                
-                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-                let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-                
-                task.waitUntilExit()
-                
-                if task.terminationStatus != 0 {
-                    let errorMessage = String(data: errorData, encoding: .utf8) ?? "Unknown error"
-                    continuation.resume(throwing: OSQueryError.executionFailed(errorMessage))
-                    return
-                }
-                
-                guard let jsonString = String(data: outputData, encoding: .utf8),
-                      let jsonData = jsonString.data(using: .utf8) else {
-                    continuation.resume(throwing: OSQueryError.invalidOutput("Could not decode output as UTF-8"))
-                    return
-                }
-                
-                do {
-                    if let jsonArray = try JSONSerialization.jsonObject(with: jsonData) as? [[String: Any]] {
-                        continuation.resume(returning: jsonArray)
-                    } else {
-                        continuation.resume(throwing: OSQueryError.invalidOutput("Output is not a JSON array"))
-                    }
-                } catch {
-                    continuation.resume(throwing: OSQueryError.jsonDecodingFailed(error))
-                }
-                
             } catch {
-                continuation.resume(throwing: OSQueryError.processLaunchFailed(error))
+                throw OSQueryError.processLaunchFailed(error)
             }
-        }
+            processBox.attach(task)
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            task.waitUntilExit()
+
+            // If the process was killed (e.g. timeout), surface a clean error so
+            // the parent's race resolution stays deterministic. The parent has
+            // already thrown OSQueryError.timeout in that case; this throw just
+            // unblocks the group cleanly.
+            if task.terminationReason == .uncaughtSignal {
+                throw OSQueryError.executionFailed("osqueryi terminated by signal")
+            }
+
+            if task.terminationStatus != 0 {
+                let errorMessage = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+                throw OSQueryError.executionFailed(errorMessage)
+            }
+
+            guard let jsonString = String(data: outputData, encoding: .utf8),
+                  let jsonData = jsonString.data(using: .utf8) else {
+                throw OSQueryError.invalidOutput("Could not decode output as UTF-8")
+            }
+
+            do {
+                if let jsonArray = try JSONSerialization.jsonObject(with: jsonData) as? [[String: Any]] {
+                    return QueryRows(rows: jsonArray)
+                } else {
+                    throw OSQueryError.invalidOutput("Output is not a JSON array")
+                }
+            } catch let error as OSQueryError {
+                throw error
+            } catch {
+                throw OSQueryError.jsonDecodingFailed(error)
+            }
+        }.value
+        return box.rows
     }
     
-    /// Execute an osquery query with extension support
-    /// Uses delayed stdin approach to ensure extension has time to register before query runs
-    /// The extension takes ~6 seconds to fully register its tables
-    private func executeQueryWithExtension(_ query: String) async throws -> [[String: Any]] {
-        return try await withCheckedThrowingContinuation { continuation in
-            // WORKAROUND: osquery extension loading is asynchronous.
-            // When using --extension flag, the extension process starts but tables
-            // aren't immediately available. If we send the query too soon, it fails
-            // with "no such table" error.
-            //
-            // Solution: Use bash to delay query input until extension has registered.
-            // We pipe the query via a subshell that sleeps first.
-            
+    /// Execute an osquery query with extension support.
+    /// Uses a bash subshell that sleeps 7s before sending the query, giving the
+    /// macadmins extension time to register its tables. The bash process is the
+    /// one we kill on timeout — terminating it brings down the osqueryi child
+    /// and unblocks the pipe reads here.
+    private static func runExtensionQuery(_ query: String, osqueryPath: String, extensionPath: String, processBox: ProcessBox) async throws -> [[String: Any]] {
+        let box = try await Task.detached(priority: .userInitiated) { () throws -> QueryRows in
             let task = Process()
             task.executableURL = URL(fileURLWithPath: "/bin/bash")
-            
-            // Escape the query for shell
+
             let escapedQuery = query.replacingOccurrences(of: "'", with: "'\"'\"'")
-            
-            // Use bash -c with a subshell that:
-            // 1. Sleeps 7 seconds to let extension register
-            // 2. Sends the query
-            // 3. Sends .exit to close osqueryi
-            // The pipe to osqueryi waits for input, giving extension time to load
+
             let script = """
-            (sleep 7 && echo '\(escapedQuery)' && echo '.exit') | "\(osqueryPath)" --json --extension "\(extensionPath!)" --extensions_timeout 15
+            (sleep 7 && echo '\(escapedQuery)' && echo '.exit') | "\(osqueryPath)" --json --extension "\(extensionPath)" --extensions_timeout 15
             """
-            
+
             task.arguments = ["-c", script]
-            
+
             let outputPipe = Pipe()
             let errorPipe = Pipe()
             task.standardOutput = outputPipe
             task.standardError = errorPipe
-            
+
             do {
                 try task.run()
-                
-                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-                let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-                
-                task.waitUntilExit()
-                
-                guard let outputString = String(data: outputData, encoding: .utf8) else {
-                    continuation.resume(throwing: OSQueryError.invalidOutput("Could not decode output as UTF-8"))
-                    return
-                }
-                
-                // Debug: log output for extension debugging (only when verbose)
-                let errorString = String(data: errorData, encoding: .utf8) ?? ""
-                if ConsoleFormatter.verboseLevel >= 3 {
-                    if !errorString.isEmpty && (errorString.contains("error") || errorString.contains("Error")) {
-                        ConsoleFormatter.writeDebug("OSQuery stderr: \(errorString.prefix(200))...")
-                    }
-                }
-                ConsoleFormatter.writeDebug("OSQuery output length: \(outputString.count) chars")
-                
-                // Find the JSON array in the output (starts with [ and ends with ])
-                if let jsonStart = outputString.firstIndex(of: "["),
-                   let jsonEnd = outputString.lastIndex(of: "]") {
-                    let jsonString = String(outputString[jsonStart...jsonEnd])
-                    
-                    if let jsonData = jsonString.data(using: .utf8) {
-                        do {
-                            if let jsonArray = try JSONSerialization.jsonObject(with: jsonData) as? [[String: Any]] {
-                                continuation.resume(returning: jsonArray)
-                                return
-                            }
-                        } catch {
-                            // JSON parsing failed, check if it's an error response
-                        }
-                    }
-                }
-                
-                // Check for errors in stderr or output
-                if outputString.contains("no such table") || errorString.contains("no such table") {
-                    continuation.resume(throwing: OSQueryError.executionFailed("no such table"))
-                    return
-                }
-                
-                // If task failed with non-zero exit code
-                if task.terminationStatus != 0 {
-                    let errorMessage = errorString.isEmpty ? "osquery exited with code \(task.terminationStatus)" : errorString
-                    continuation.resume(throwing: OSQueryError.executionFailed(errorMessage))
-                    return
-                }
-                
-                // If we got here with no JSON, return empty array
-                if outputString.isEmpty {
-                    let errorMessage = errorString.isEmpty ? "No output from osquery" : errorString
-                    continuation.resume(throwing: OSQueryError.executionFailed(errorMessage))
-                } else {
-                    // No valid JSON found but also no error - might be an empty result
-                    continuation.resume(returning: [])
-                }
-                
             } catch {
-                continuation.resume(throwing: OSQueryError.processLaunchFailed(error))
+                throw OSQueryError.processLaunchFailed(error)
             }
-        }
+            processBox.attach(task)
+
+            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            task.waitUntilExit()
+
+            guard let outputString = String(data: outputData, encoding: .utf8) else {
+                throw OSQueryError.invalidOutput("Could not decode output as UTF-8")
+            }
+
+            let errorString = String(data: errorData, encoding: .utf8) ?? ""
+
+            if task.terminationReason == .uncaughtSignal {
+                throw OSQueryError.executionFailed("osqueryi (extension) terminated by signal")
+            }
+
+            if ConsoleFormatter.verboseLevel >= 3 {
+                if !errorString.isEmpty && (errorString.contains("error") || errorString.contains("Error")) {
+                    ConsoleFormatter.writeDebug("OSQuery stderr: \(errorString.prefix(200))...")
+                }
+            }
+            ConsoleFormatter.writeDebug("OSQuery output length: \(outputString.count) chars")
+
+            if let jsonStart = outputString.firstIndex(of: "["),
+               let jsonEnd = outputString.lastIndex(of: "]") {
+                let jsonString = String(outputString[jsonStart...jsonEnd])
+
+                if let jsonData = jsonString.data(using: .utf8),
+                   let jsonArray = (try? JSONSerialization.jsonObject(with: jsonData)) as? [[String: Any]] {
+                    return QueryRows(rows: jsonArray)
+                }
+            }
+
+            if outputString.contains("no such table") || errorString.contains("no such table") {
+                throw OSQueryError.executionFailed("no such table")
+            }
+
+            if task.terminationStatus != 0 {
+                let errorMessage = errorString.isEmpty ? "osquery exited with code \(task.terminationStatus)" : errorString
+                throw OSQueryError.executionFailed(errorMessage)
+            }
+
+            if outputString.isEmpty {
+                let errorMessage = errorString.isEmpty ? "No output from osquery" : errorString
+                throw OSQueryError.executionFailed(errorMessage)
+            }
+
+            return QueryRows(rows: [])
+        }.value
+        return box.rows
     }
     
-    /// Execute multiple queries from a module configuration with progress display
+    /// Execute multiple queries from a module configuration with progress display.
+    /// Each query emits started / ok / timeout lines under -v so a hung table is
+    /// self-diagnosing. A timed-out or failed query yields an empty result and
+    /// the module continues with the remaining queries — never let one bad
+    /// table take down the whole module's transmit.
     public func executeModuleQueries(_ queries: [String: String], showProgress: Bool = true) async -> [String: [[String: Any]]] {
         var results: [String: [[String: Any]]] = [:]
-        
+
         let queryArray = Array(queries)
         let totalQueries = queryArray.count
-        
-        // Show header for osquery execution
+
         if showProgress && totalQueries > 0 && ConsoleFormatter.isVerbose {
             ConsoleFormatter.writeInfo("Executing \(totalQueries) osquery queries")
         }
-        
-        // Execute queries sequentially with progress tracking
+
         for (index, (key, query)) in queryArray.enumerated() {
-            // Show progress bar for each query
             if showProgress {
                 ConsoleFormatter.writeQueryProgress(queryName: key, current: index + 1, total: totalQueries)
             }
-            
+
+            ConsoleFormatter.writeInfo("query \(key) status=started")
+            let start = Date()
+
             do {
                 let result = try await executeQuery(query)
+                let elapsed = Date().timeIntervalSince(start)
+                ConsoleFormatter.writeInfo("query \(key) status=ok rows=\(result.count) elapsed=\(String(format: "%.1fs", elapsed))")
                 results[key] = result
+            } catch let OSQueryError.timeout(seconds) {
+                let elapsed = Date().timeIntervalSince(start)
+                ConsoleFormatter.writeWarning("query \(key) status=timeout budget=\(String(format: "%.0fs", seconds)) elapsed=\(String(format: "%.1fs", elapsed)) -- skipping")
+                results[key] = []
             } catch {
-                if ConsoleFormatter.isVerbose {
-                    ConsoleFormatter.writeWarning("Query '\(key)' failed: \(error)")
-                }
+                let elapsed = Date().timeIntervalSince(start)
+                ConsoleFormatter.writeWarning("query \(key) status=failed elapsed=\(String(format: "%.1fs", elapsed)) error=\(error)")
                 results[key] = []
             }
         }
-        
+
         return results
     }
     
@@ -383,7 +477,8 @@ public enum OSQueryError: Error, LocalizedError {
     case processLaunchFailed(Error)
     case invalidOutput(String)
     case jsonDecodingFailed(Error)
-    
+    case timeout(TimeInterval)
+
     public var errorDescription: String? {
         switch self {
         case .executionFailed(let message):
@@ -394,6 +489,8 @@ public enum OSQueryError: Error, LocalizedError {
             return "Invalid osquery output: \(message)"
         case .jsonDecodingFailed(let error):
             return "Failed to decode JSON output: \(error.localizedDescription)"
+        case .timeout(let seconds):
+            return "OSQuery exceeded timeout of \(String(format: "%.0fs", seconds))"
         }
     }
 }

--- a/Sources/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig
+++ b/Sources/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ReportMate macOS Client — Privacy Preferences Policy Control (PPPC) template
+
+  Bundled sample profile. Grants the TCC permissions ReportMate needs to collect
+  full system telemetry on managed Macs. Deploy via your MDM (Intune, Jamf, Kandji,
+  Mosyle, etc.) or vendor it through Munki — TCC entries delivered by an MDM
+  profile do not prompt the user.
+
+  Why three identifiers, not one:
+    TCC permissions do NOT inherit to child processes. The runner shells out to
+    osqueryi, and osqueryi loads the macadmins extension as its own process. All
+    three need their own grants or the management module will hang in a sandbox
+    check that has no UI to resolve.
+
+  Before deploying:
+    1. Replace PayloadOrganization with your organization name.
+    2. Replace the top-level PayloadIdentifier with your reverse-DNS prefix
+       (e.g. "com.example.it.ReportMatePrefs").
+    3. Regenerate the two PayloadUUIDs (`uuidgen`).
+    4. Verify the CodeRequirements still match your shipping binaries
+       (`codesign -d -r-` on each). The Team IDs in this template are the
+       upstream ReportMate / osquery / macadmins signing identities; if you
+       ship resigned builds, update accordingly.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadIdentifier</key>
+			<string>com.github.reportmate.pppc</string>
+			<key>PayloadType</key>
+			<string>com.apple.TCC.configuration-profile-policy</string>
+			<key>PayloadUUID</key>
+			<string>CCBE058F-D082-4C40-8A04-4443E15BCDFD</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>Services</key>
+			<dict>
+				<key>AppleEvents</key>
+				<array>
+					<dict>
+						<key>AEReceiverCodeRequirement</key>
+						<string>identifier "com.apple.systemevents" and anchor apple</string>
+						<key>AEReceiverIdentifier</key>
+						<string>com.apple.systemevents</string>
+						<key>AEReceiverIdentifierType</key>
+						<string>bundleID</string>
+						<key>Authorization</key>
+						<string>Allow</string>
+						<key>CodeRequirement</key>
+						<string>identifier "com.github.reportmate.managedreportsrunner" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TF6CSP83S"</string>
+						<key>Comment</key>
+						<string>ReportMate macOS Client - System Events automation</string>
+						<key>Identifier</key>
+						<string>com.github.reportmate.managedreportsrunner</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+					</dict>
+				</array>
+				<key>SystemPolicyAllFiles</key>
+				<array>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "com.github.reportmate.managedreportsrunner" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TF6CSP83S"</string>
+						<key>Comment</key>
+						<string>ReportMate macOS Client - Full Disk Access for system telemetry collection</string>
+						<key>Identifier</key>
+						<string>com.github.reportmate.managedreportsrunner</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+					</dict>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "io.osquery.agent" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3522FA9PXF"</string>
+						<key>Comment</key>
+						<string>osquery (shelled out by ReportMate) - Full Disk Access for the managed_policies table, which reads TCC-protected /Library/Managed Preferences/ plists. Without this grant, osqueryi hangs in a TCC check that has no UI to resolve, and the management module never completes.</string>
+						<key>Identifier</key>
+						<string>io.osquery.agent</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+					</dict>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "macadmins_extension" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "T4SK8ZXCXG"</string>
+						<key>Comment</key>
+						<string>macadmins osquery extension (loaded by managedreportsrunner via --extension). Runs as its own process with its own TCC identity; without an independent FDA grant the extension hangs in a sandbox check and osqueryi blocks waiting on its socket.</string>
+						<key>Identifier</key>
+						<string>macadmins_extension</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+					</dict>
+				</array>
+				<key>SystemPolicySysAdminFiles</key>
+				<array>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "com.github.reportmate.managedreportsrunner" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TF6CSP83S"</string>
+						<key>Comment</key>
+						<string>ReportMate macOS Client - System Admin Files for MDM and profile data</string>
+						<key>Identifier</key>
+						<string>com.github.reportmate.managedreportsrunner</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+					</dict>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "io.osquery.agent" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3522FA9PXF"</string>
+						<key>Comment</key>
+						<string>osquery (shelled out by ReportMate) - System Admin Files for MDM and profile data reads.</string>
+						<key>Identifier</key>
+						<string>io.osquery.agent</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+					</dict>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "macadmins_extension" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "T4SK8ZXCXG"</string>
+						<key>Comment</key>
+						<string>macadmins osquery extension - System Admin Files for the MDM/profiles tables it adds to osquery.</string>
+						<key>Identifier</key>
+						<string>macadmins_extension</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+					</dict>
+				</array>
+			</dict>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Grants Full Disk Access and System Admin Files permissions to the ReportMate macOS client (managedreportsrunner), the osquery binary it shells out to, and the macadmins osquery extension it loads. Required for full system telemetry collection.</string>
+	<key>PayloadDisplayName</key>
+	<string>ReportMate Full Disk Access</string>
+	<key>PayloadIdentifier</key>
+	<string>com.github.reportmate.pppc.template</string>
+	<key>PayloadOrganization</key>
+	<string>ReportMate Contributors</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>92B39484-F7D7-4D0B-B4E6-036F75491A46</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/build.sh
+++ b/build.sh
@@ -710,6 +710,23 @@ WRAPPER
         log_info "Download from: https://github.com/macadmins/osquery-extension/releases"
     fi
 
+    # ═══════════════════════════════════════════════════════════════════════════
+    # PPPC PROFILE TEMPLATE
+    # ═══════════════════════════════════════════════════════════════════════════
+    # Vendor-neutral sample profile granting FDA + SysAdminFiles to the three
+    # binaries in the collection chain (runner, osqueryi, macadmins extension).
+    # Shipped so admins can grab it from /Applications/Utilities/ReportMate.app/
+    # Contents/Resources/profiles/ and adapt for their MDM.
+
+    PPPC_SOURCE="${SCRIPT_DIR}/Sources/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig"
+    if [ -f "$PPPC_SOURCE" ]; then
+        mkdir -p "$APP_RESOURCES/profiles"
+        cp "$PPPC_SOURCE" "$APP_RESOURCES/profiles/ReportMate-FullDiskAccess.mobileconfig"
+        log_success "PPPC profile template bundled: Contents/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig"
+    else
+        log_warn "PPPC profile template not found at: $PPPC_SOURCE"
+    fi
+
     # Create Info.plist for app bundle
     cat > "$APP_CONTENTS/Info.plist" << EOF
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary
Reported by ECU IT: ~250 Intune-managed Macs see the hourly LaunchDaemon silently stop transmitting the management module's data. Root cause is that `osqueryi`'s `--extensions_timeout 15` only bounds extension *registration* - a single misbehaving table (most often `sofa_unpatched_cves` fetching the SOFA feed live) blocks the entire module's collection indefinitely. Process tree shows osqueryi inside `sqlite3_step -> xFilter -> pthread_join` waiting on the extension forever.

This PR adds per-query + per-module timeouts so a hung table can no longer take down a whole collection, plus a bundled PPPC profile template covering the three binaries in the chain (TCC perms don't inherit to subprocesses, which was the *first* hang ECU hit before the SOFA one).

## Changes

**Per-query timeout - `OSQueryService.swift`**
- `executeQuery` now races each query against a budget via `withThrowingTaskGroup`. On timeout the child `osqueryi`/`bash` process is `SIGTERM`-ed, given 2s grace, then `SIGKILL`-ed through a thread-safe `ProcessBox`. The awaiting pipe reads EOF and the query resolves with `OSQueryError.timeout`.
- `executeModuleQueries` treats timeouts and other failures the same way (empty rows) so the module continues with partial data.
- Per-table `started` / `ok rows=N elapsed=Xs` / `timeout budget=Xs ... skipping` lines under `-v` make the failure mode self-diagnosing.

**Per-module timeout - `DataCollectionService.swift`**
- Every `processor.collectData()` is wrapped in a `moduleTimeoutSeconds` wall-clock race as a defensive layer. A timed-out module is skipped and every other module still transmits.

**Configuration - `ConfigurationManager.swift`**
- `queryTimeoutSeconds` (default 30s)
- `extensionQueryTimeoutSeconds` (default 60s - covers the existing 7s extension warmup plus the extension's own registration and the query itself)
- `moduleTimeoutSeconds` (default 120s)
- Plist keys + `REPORTMATE_QUERY_TIMEOUT` / `REPORTMATE_EXTENSION_QUERY_TIMEOUT` / `REPORTMATE_MODULE_TIMEOUT` env vars

**PPPC profile template - `Sources/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig` (new)**
- Vendor-neutral sample with `AppleEvents` + `SystemPolicyAllFiles` + `SystemPolicySysAdminFiles` entries for all three binaries:
  - `com.github.reportmate.managedreportsrunner` (Team `7TF6CSP83S`)
  - `io.osquery.agent` (Team `3522FA9PXF`)
  - `macadmins_extension` (Team `T4SK8ZXCXG`)
- Header comment explains why three identifiers are needed (TCC perms don't inherit) and what admins should change before deploying.
- `build.sh` copies it into `Contents/Resources/profiles/` so admins can grab it from a deployed bundle. `Package.swift`'s existing `.copy("Resources")` already picks up the new subdir for the SPM bundle.

## Test plan

- [ ] `sudo managedreportsrunner --run-modules management -vv` completes in well under the 60s extension budget on a device with no SOFA cache
- [ ] When a query times out, the module's other queries still produce data; the API's `/api/v1/devices/management` `collectedAt` advances and the module payload is missing only the slow table's rows
- [ ] `-v` output shows per-table `started` / `ok rows=N elapsed=Xs` / `timeout budget=Xs ... skipping` lines
- [ ] When a whole module times out, the runner logs `module X status=timeout ... skipping, other modules will still transmit` and the rest of the payload still POSTs
- [ ] `swift build` clean on all four targets (`managedreportsrunner`, `ReportMateApp`, `ReportMateHelper`, `reportmate-appusage`) - verified locally
- [ ] After deploying the bundled PPPC template via MDM, the hand-run hang in `libsystem_sandbox.dylib` no longer reproduces

## Deferred (not in this PR)

- On-disk SOFA feed cache (belongs upstream in `macadmins/osquery-extension`)
- Splitting `sofa_*` queries into a dedicated `cve` module with a daily schedule

Both are tracked - the timeout layer makes them less urgent because a hung SOFA query is now bounded instead of fatal.