### PR TITLE
ci: fix component.plist path to match installer layout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -543,7 +543,7 @@ jobs:
                   <key>BundleOverwriteAction</key>
                   <string>upgrade</string>
                   <key>RootRelativeBundlePath</key>
-                  <string>usr/local/reportmate/ReportMate.app</string>
+                  <string>Applications/Utilities/ReportMate.app</string>
               </dict>
           </array>
           </plist>


### PR DESCRIPTION
## Summary

Every PR and push to `main` since at least mid-April has had the `Build macOS Client` workflow red at the `Create PKG installer` step:

```
pkgbuild: error: Component path
"build/output/package_root/usr/local/reportmate/ReportMate.app"
does not exist.
```

`build.sh` installs the app bundle at `/Applications/Utilities/ReportMate.app` and ships a thin wrapper at `/usr/local/reportmate/managedreportsrunner` that forwards into it (per `CLAUDE.md`). The workflow's pkgbuild component.plist, however, still declares the bundle's `RootRelativeBundlePath` as `usr/local/reportmate/ReportMate.app` — that path is never created, so `pkgbuild` aborts.

Every other reference in the workflow already points at the correct location (`APP_BUNDLE` at line 266, the launchdaemon `ProgramArguments` at line 364, the wrapper target at line 292, etc.) — this one line is just stale.

## Test plan
- [ ] `Build macOS Client` CI run on this PR turns green at the `Create PKG installer` step
- [ ] Resulting PKG installs the app at `/Applications/Utilities/ReportMate.app` (matches local `build.sh` behavior, no behavior change to the produced installer aside from the layout actually matching the on-disk truth)