### PR TITLE
Replace osascript login item collection with sfltool dumpbtm

### DIFF
--- a/Sources/DataCollection/Modules/ApplicationsModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/ApplicationsModuleProcessor.swift
@@ -350,13 +350,26 @@ public class ApplicationsModuleProcessor: BaseModuleProcessor, @unchecked Sendab
                 echo "{\\"name\\": \\"$label_escaped\\", \\"path\\": \\"$program_escaped\\", \\"type\\": \\"LaunchAgent\\", \\"source\\": \\"Local\\", \\"status\\": \\"$status\\"},"
             done
             
-            # Get Login Items via osascript (if available)
-            osascript -e 'tell application "System Events" to get the name of every login item' 2>/dev/null | tr ',' '\\n' | while read -r item; do
-                item=$(echo "$item" | xargs)
-                [ -z "$item" ] && continue
-                item_escaped=$(echo "$item" | sed 's/"/\\\\"/g')
-                echo "{\\"name\\": \\"$item_escaped\\", \\"path\\": \\"\\", \\"type\\": \\"LoginItem\\", \\"source\\": \\"User\\", \\"status\\": \\"Enabled\\"},"
-            done
+            # Get Login Items from BackgroundTaskManagement (sfltool, root only - no Apple Events / TCC prompt)
+            if [ "$(id -u)" -eq 0 ]; then
+                sfltool dumpbtm 2>/dev/null | awk '
+                    function emit() {
+                        if (type ~ /login item/ && name != "" && name != "(null)") {
+                            status = (disp ~ /enabled/) ? "Enabled" : "Disabled"
+                            gsub(/"/, "", name); gsub(/"/, "", url)
+                            sub(/^file:\\/\\//, "", url); sub(/\\/$/, "", url)
+                            printf "{\\"name\\": \\"%s\\", \\"path\\": \\"%s\\", \\"type\\": \\"LoginItem\\", \\"source\\": \\"User\\", \\"status\\": \\"%s\\"},\\n", name, url, status
+                        }
+                        name=""; type=""; disp=""; url=""
+                    }
+                    /^[[:space:]]*#[0-9]+:/ { emit() }
+                    /^[[:space:]]*Name:/ { name=$0; sub(/^[[:space:]]*Name:[[:space:]]*/, "", name) }
+                    /^[[:space:]]*Type:/ { type=$0 }
+                    /^[[:space:]]*Disposition:/ { disp=$0 }
+                    /^[[:space:]]*URL:/ { url=$0; sub(/^[[:space:]]*URL:[[:space:]]*/, "", url) }
+                    END { emit() }
+                '
+            fi
             
             echo "{}]" | sed 's/,{}]/]/'
         """


### PR DESCRIPTION
## Why

On macOS 27 beta (Golden Gate) the app throws the TCC consent prompt **"ReportMate wants access to control System Events"**. Root cause: the applications module's startup-items bash fallback ran

`osascript -e 'tell application "System Events" to get the name of every login item'`

Sending an Apple Event to System Events is what triggers the `kTCCServiceAppleEvents` prompt. It only surfaced now because the fallback only runs when the osquery `launchd` query fails or returns empty — which it does on the macOS 27 beta.

## Change

Replace the osascript block with parsing of `sfltool dumpbtm` (BackgroundTaskManagement):

- No Apple Events entitlement, no TCC prompt — the requirement is gone entirely (this was the only osascript/AppleScript use in the client).
- Works under the root LaunchDaemons (`sfltool dumpbtm` requires root; the block is guarded with an `id -u` check).
- Captures modern SMAppService login items in addition to legacy ones — the System Events API only ever saw the legacy list.
- Same JSON item shape (`LoginItem` type) as before, including enabled/disabled status which the old code hardcoded to Enabled.

## Verification

- `swift build` passes.
- Parser validated against representative `sfltool dumpbtm` output: legacy and SMAppService login items extracted with correct status; daemons/agents and null-named records excluded.
- Confirmed via `strings` that the compiled binary embeds the exact bash that was tested.