### PR TITLE
Attribute app usage to the process owner, not the watcher daemon

### DIFF
--- a/Sources/Watcher/Watcher/AppUsageWatcher.swift
+++ b/Sources/Watcher/Watcher/AppUsageWatcher.swift
@@ -144,9 +144,9 @@ public final class AppUsageWatcher: @unchecked Sendable {
         let bundleId = app.bundleIdentifier
         let appName = app.localizedName ?? bundleURL.deletingPathExtension().lastPathComponent
         let path = bundleURL.path
-        let user = NSUserName()
         let pid = Int(app.processIdentifier)
-        
+        let user = processOwner(pid: pid) ?? NSUserName()
+
         logger.info("App launched: \(appName) (PID: \(pid))")
         
         do {
@@ -273,9 +273,9 @@ public final class AppUsageWatcher: @unchecked Sendable {
             let bundleId = app.bundleIdentifier
             let appName = app.localizedName ?? bundleURL.deletingPathExtension().lastPathComponent
             let path = bundleURL.path
-            let user = NSUserName()
             let pid = Int(app.processIdentifier)
-            
+            let user = processOwner(pid: pid) ?? NSUserName()
+
             // Try to get actual start time from process info
             let startTime = getProcessStartTime(pid: pid) ?? Date()
             
@@ -293,6 +293,42 @@ public final class AppUsageWatcher: @unchecked Sendable {
         logger.info("Reconciled \(appsToReconcile.count) running applications")
     }
     
+    /// The user a running process belongs to, or nil if it can't be determined.
+    ///
+    /// The watcher runs as a root LaunchDaemon, so `NSUserName()` reports the
+    /// daemon's own identity rather than the person at the keyboard. Reading the
+    /// owner from the observed process attributes each session to the right user
+    /// and stays correct across fast user switching. The uid is read rather than
+    /// `ps -o user=`, which truncates usernames past eight characters.
+    private func processOwner(pid: Int) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-o", "uid=", "-p", "\(pid)"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+
+            guard let output = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                  let uid = uid_t(output),
+                  let entry = getpwuid(uid) else {
+                return nil
+            }
+
+            let name = String(cString: entry.pointee.pw_name)
+            return name.isEmpty ? nil : name
+        } catch {
+            logger.debug("Could not resolve owner of PID \(pid): \(error)")
+            return nil
+        }
+    }
+
     /// Get process start time using ps command
     private func getProcessStartTime(pid: Int) -> Date? {
         let process = Process()


### PR DESCRIPTION
## Problem

The appusage watcher runs as a root LaunchDaemon (`com.github.reportmate.appusage.plist`, installed to `/Library/LaunchDaemons`), so `NSUserName()` in `AppUsageWatcher` returned the *daemon's* identity. Every session on every Mac was recorded as `root`.

Measured against production today: **204 lab Macs report exactly one distinct user** (`root`), while Windows machines in the same rooms report hundreds. This makes macOS usage data unusable for any per-person question — including "who is actually using the library lab", which is what prompted this.

## Fix

Resolve the owner from the *observed process* rather than the calling process, so each session is attributed to whoever is running the app. This also stays correct across fast user switching, which a global console-user lookup would not.

The uid is read and mapped through `getpwuid` rather than using `ps -o user=`, which truncates usernames past eight characters — several ECUAD accounts are longer. `NSUserName()` remains a fallback for the race where the process has already exited.

## Verification

- Builds clean (`swift build --product reportmate-appusage`).
- **Mechanism:** a non-root caller reading pid 1 (launchd) resolves to `root`, not to the caller — confirming the lookup follows the observed process. Production inverts this: a root daemon observing a student's app resolves to the student.
- **End to end:** ran the watcher against a temp database; all 59 live sessions were attributed to the logged-in user rather than to the daemon.

Root privileges aren't available non-interactively here, so the root-daemon path itself hasn't been exercised on a live machine — worth confirming on one lab Mac after the next build.

## Scope

User attribution only. The separate duration double-count (`confirmTransmission()` is never called, so the client re-sends its whole session history each cycle and the server accumulates it) is filed separately — this PR does not touch it.