### PR TITLE
Stop re-sending app usage that has already been reported

### DIFF
--- a/Sources/DataCollection/Services/ApplicationUsageService.swift
+++ b/Sources/DataCollection/Services/ApplicationUsageService.swift
@@ -151,25 +151,28 @@ public class ApplicationUsageService: @unchecked Sendable {
         return snapshot
     }
     
-    /// Mark transmitted data for deletion (called after successful API transmission)
+    /// Retire the sessions that were just delivered. Call only after the API has
+    /// confirmed success — until this runs, the same sessions are collected again
+    /// on the next cycle and the server adds their duration a second time.
     public func confirmTransmission() {
         guard !transmittedSessionIds.isEmpty else { return }
-        
+
         do {
             let db = try Connection(dbPath)
-            
-            // Two-phase delete: First mark as transmitted
+
+            // Marking before deleting keeps this safe to interrupt: a crash
+            // between the two statements leaves the batch flagged, which excludes
+            // it from the next collection and lets the following call clear it.
             let sessions = Table("app_sessions")
             let id = Expression<Int64>("id")
             let transmitted = Expression<Bool>("transmitted")
-            
+
             let toUpdate = sessions.filter(transmittedSessionIds.contains(id))
             try db.run(toUpdate.update(transmitted <- true))
-            
-            // Delete previously transmitted sessions (from last cycle)
+
             let toDelete = sessions.filter(transmitted == true)
             try db.run(toDelete.delete())
-            
+
             transmittedSessionIds = []
         } catch {
             print("Warning: Failed to mark sessions as transmitted: \(error)")
@@ -243,7 +246,12 @@ public class ApplicationUsageService: @unchecked Sendable {
             session.isActive = isActive
             
             result.append(session)
-            sessionIds.append(rowId)
+            // Only completed sessions are eligible for retirement. A running app
+            // is still accruing time, so it stays in the database until it exits
+            // and contributes its duration once, when it is final.
+            if !isActive {
+                sessionIds.append(rowId)
+            }
             totalLaunches += 1
         }
         
@@ -377,6 +385,13 @@ public class ApplicationUsageService: @unchecked Sendable {
     /// Build daily per-application usage summaries from sessions.
     /// Groups by (date, app name). Cumulative: last collection of the day wins (UPSERT on API).
     public func buildDailySummaries(sessions: [ApplicationUsageSession]) -> [[String: Any]] {
+        // The server accumulates these totals per (device, date, app), so every
+        // session must appear here exactly once, in the cycle it completes.
+        // Running apps are excluded: their duration grows between cycles, so
+        // sending them repeatedly would add the same app-open several times over.
+        // They are counted once they exit; `sessions` still carries them for the
+        // snapshot's live view.
+        let sessions = sessions.filter { !$0.isActive }
         guard !sessions.isEmpty else { return [] }
 
         let dateFormatter = DateFormatter()

--- a/Sources/DataCollection/Services/ApplicationUsageService.swift
+++ b/Sources/DataCollection/Services/ApplicationUsageService.swift
@@ -167,8 +167,18 @@ public class ApplicationUsageService: @unchecked Sendable {
             let id = Expression<Int64>("id")
             let transmitted = Expression<Bool>("transmitted")
 
-            let toUpdate = sessions.filter(transmittedSessionIds.contains(id))
-            try db.run(toUpdate.update(transmitted <- true))
+            // The first confirmation after a long backlog can carry tens of
+            // thousands of ids; a single IN-list that size exceeds SQLite's
+            // bound-variable limit and would abort the whole batch. Mark in
+            // chunks so the machines with the worst backlogs still converge.
+            let chunkSize = 500
+            var start = 0
+            while start < transmittedSessionIds.count {
+                let end = min(start + chunkSize, transmittedSessionIds.count)
+                let chunk = Array(transmittedSessionIds[start..<end])
+                try db.run(sessions.filter(chunk.contains(id)).update(transmitted <- true))
+                start = end
+            }
 
             let toDelete = sessions.filter(transmitted == true)
             try db.run(toDelete.delete())

--- a/Sources/ReportMateClient.swift
+++ b/Sources/ReportMateClient.swift
@@ -234,15 +234,14 @@ struct ReportMateClient: AsyncParsableCommand {
         return "macOS \(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
     }
     
-    private func createProcessor(for module: String, config: ReportMateConfiguration) -> ModuleProcessor? {
+    private func createProcessor(for module: String, config: ReportMateConfiguration, usageService: ApplicationUsageService) -> ModuleProcessor? {
         switch module.lowercased() {
         case "hardware": return HardwareModuleProcessor(configuration: config)
         case "system": return SystemModuleProcessor(configuration: config)
         case "network": return NetworkModuleProcessor(configuration: config)
         case "security": return SecurityModuleProcessor(configuration: config)
-        case "applications": 
+        case "applications":
             // Application usage service for usage tracking from SQLite database
-            let usageService = ApplicationUsageService()
             return ApplicationsModuleProcessor(configuration: config, applicationUsageService: usageService)
         case "management": return ManagementModuleProcessor(configuration: config)
         case "inventory": return InventoryModuleProcessor(configuration: config)
@@ -255,12 +254,12 @@ struct ReportMateClient: AsyncParsableCommand {
         }
     }
     
-    private func executeModule(module: String, config: ReportMateConfiguration, logger: Logger, current: Int = 1, total: Int = 1) async throws -> (String, Any)? {
+    private func executeModule(module: String, config: ReportMateConfiguration, logger: Logger, usageService: ApplicationUsageService, current: Int = 1, total: Int = 1) async throws -> (String, Any)? {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "HH:mm:ss"
         let timestamp = dateFormatter.string(from: Date())
-        
-        guard let processor = createProcessor(for: module, config: config) else {
+
+        guard let processor = createProcessor(for: module, config: config, usageService: usageService) else {
             logger.warning("Unknown module: \(module)")
             ConsoleFormatter.writeWarning("Unknown module: \(module)")
             return nil
@@ -355,9 +354,13 @@ struct ReportMateClient: AsyncParsableCommand {
         // But for now, we just run what's requested. 
         // Ideally, we should ensure 'inventory' is run if we plan to transmit, to build the DeviceInfo.
         
+        // Owned here rather than per-module: the sessions it collects can only be
+        // retired once the API confirms delivery, which happens after this loop.
+        let usageService = ApplicationUsageService()
+
         let totalModules = modulesToRun.count
         for (index, module) in modulesToRun.enumerated() {
-            if let (moduleName, data) = try await executeModule(module: module, config: config, logger: logger, current: index + 1, total: totalModules) {
+            if let (moduleName, data) = try await executeModule(module: module, config: config, logger: logger, usageService: usageService, current: index + 1, total: totalModules) {
                 collectedData[moduleName] = data
             }
         }
@@ -510,6 +513,7 @@ struct ReportMateClient: AsyncParsableCommand {
                 case .success(let response):
                     print("[\(completionTimestamp)] INFO  Transmission successful: \(response.message ?? "No message")")
                     logger.info("Transmission successful. Records processed: \(response.recordsProcessed)")
+                    usageService.confirmTransmission()
                 case .failure(let error):
                     print("[\(completionTimestamp)] ERROR Transmission failed: \(error.localizedDescription)")
                     logger.error("Transmission failed: \(error)")


### PR DESCRIPTION
## Problem

`confirmTransmission()` was **never called** — the only reference to it in the repo was its own definition. So no session was ever marked transmitted, and the watcher database was never pruned. Collection selects every row with `transmitted = false`, so each cycle re-sent the **entire session history**, and the API accumulates per `(device, date, app)`:

```
total_seconds = usage_history.total_seconds + EXCLUDED.total_seconds
```

The same hours were therefore added again every four hours.

### Measured on a live machine today

| | |
|---|---|
| Sessions in the DB | **8,822** |
| Marked transmitted | **0** — all of them |
| Oldest row | **2 January** (194 days) |
| Re-sent per cycle | **56,036 hours** |

~1,160 cycles × 56k hours lands in the tens of millions, which is exactly what production shows: Chrome alone reports **33M hours — 3.8x more than physically possible** (devices × days × 24h), and the fleet total is 588M hours. The `/devices/applications` Utilization view keys off `totalHours`, so it is displaying these numbers today.

## Fix

Three changes, together making each session count exactly once:

1. **Call `confirmTransmission()` on the success path.** The service is now owned by `handleDataCollection` instead of being constructed per-module inside `createProcessor` and discarded, so it survives until the API confirms delivery.
2. **Exclude running apps from the daily history.** Their duration is computed as `now - startTime` and grows between cycles, so re-sending them added the same app-open over and over. Four apps on the test machine have been open **93 hours** and contributed that figure, growing, on every cycle. They are counted once they exit; `snapshot.activeSessions` still lists them for the live view.
3. **Only retire completed sessions**, so a running app stays in the DB and reports its duration once, when final.

The misleading "two-phase delete" comment is corrected — it marks and deletes in the same call, which is safe to interrupt, but it is not two-phase.

## Verification

- Builds clean (`swift build --product managedreportsrunner`). Note `Sources/Generated/ModuleVersions.swift` is produced by `build.sh`, so a bare `swift build` needs it generated first — pre-existing, unrelated.
- Root cause confirmed against the live database (counts above), and the arithmetic reproduces the production inflation independently.

**Not yet exercised end to end:** the binary refuses to run as non-root, and sudo isn't available non-interactively here, so the transmit → `confirmTransmission` → prune path hasn't been run on a live machine. Worth one manual run before this goes wide:

```
sudo ./.build/debug/managedreportsrunner --run-module applications -vv
```

Expect the `app_sessions` row count to drop to roughly the still-running sessions afterwards.

## Note on existing data

The current history **cannot be repaired** — it is a sum of overlapping re-sends with no way to recover the originals. This makes data correct from deployment forward only.

Independent of #11 (user attribution); different files, no conflict.