### PR TITLE
Send X-API-Key header alongside the passphrase

### DIFF
--- a/Sources/Core/Configuration/ConfigurationManager.swift
+++ b/Sources/Core/Configuration/ConfigurationManager.swift
@@ -119,8 +119,9 @@ public class ConfigurationManager {
         // Passphrase is for device-to-api authentication
         let keyMappings: [String: String] = [
             "ApiUrl": "ApiUrl",
-            "DeviceId": "DeviceId", 
+            "DeviceId": "DeviceId",
             "Passphrase": "Passphrase",
+            "ApiKey": "ApiKey",
             "CollectionInterval": "CollectionInterval",
             "LogLevel": "LogLevel",
             "EnabledModules": "EnabledModules"
@@ -144,6 +145,7 @@ public class ConfigurationManager {
             "REPORTMATE_API_URL": "ApiUrl",
             "REPORTMATE_DEVICE_ID": "DeviceId",
             "REPORTMATE_PASSPHRASE": "Passphrase",
+            "REPORTMATE_API_KEY": "ApiKey",
             "REPORTMATE_COLLECTION_INTERVAL": "CollectionInterval",
             "REPORTMATE_LOG_LEVEL": "LogLevel",
             "REPORTMATE_QUERY_TIMEOUT": "QueryTimeoutSeconds",
@@ -206,6 +208,11 @@ public struct ReportMateConfiguration {
     /// Client passphrase for API authentication (X-Client-Passphrase header)
     /// Configured via REPORTMATE_PASSPHRASE environment variable or Passphrase plist key
     public var passphrase: String?
+    /// Scoped API key for API authentication (X-API-Key header)
+    /// Configured via REPORTMATE_API_KEY environment variable or ApiKey plist key.
+    /// Sent alongside the passphrase; the API falls through to the passphrase if the
+    /// key is absent or invalid, so this is safe to roll out incrementally.
+    public var apiKey: String?
     public var collectionInterval: Int = 3600 // 1 hour default
     public var logLevel: String = "info"
     public var enabledModules: [String] = [
@@ -255,6 +262,7 @@ public struct ReportMateConfiguration {
         if let apiUrl = other["ApiUrl"] as? String { self.apiUrl = apiUrl }
         if let deviceId = other["DeviceId"] as? String { self.deviceId = deviceId }
         if let passphrase = other["Passphrase"] as? String { self.passphrase = passphrase }
+        if let apiKey = other["ApiKey"] as? String { self.apiKey = apiKey }
         if let interval = other["CollectionInterval"] as? Int { self.collectionInterval = interval }
         if let logLevel = other["LogLevel"] as? String { self.logLevel = logLevel }
         if let modules = other["EnabledModules"] as? [String] { self.enabledModules = modules }

--- a/Sources/Core/Services/APIClient.swift
+++ b/Sources/Core/Services/APIClient.swift
@@ -45,7 +45,12 @@ public class APIClient {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = TimeInterval(configuration.timeout)
         
-        // Add authentication header
+        // Add authentication headers. Both are sent when configured: the API prefers
+        // the scoped API key and falls through to the passphrase if the key is absent
+        // or invalid, so a device can carry either or both during phase-2 rollout.
+        if let apiKey = configuration.apiKey {
+            request.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+        }
         if let passphrase = configuration.passphrase {
             request.setValue(passphrase, forHTTPHeaderField: "X-Client-Passphrase")
         }


### PR DESCRIPTION
Enables ReportMate credential phase 2 on macOS.

## Problem
The mac client only ever sent `X-Client-Passphrase`. `ConfigurationManager` had no `apiKey` property and `APIClient.transmitData` never sent `X-API-Key`, so a scoped `rm_` key could not be used on macOS even if injected into the plist.

## Change
- `ReportMateConfiguration` gains an `apiKey` field, read from the `ApiKey` plist key or `REPORTMATE_API_KEY` env var through the same user-plist / system-plist / profile / env chain as the passphrase.
- `APIClient.transmitData` sends `X-API-Key` when present, **alongside** the passphrase.

## Safety
Both headers are sent when configured. The API prefers the key and falls through to the passphrase if the key is absent or invalid (same fall-through that protects the Windows fleet), so devices roll onto keys incrementally with zero risk of breaking reporting. `swift build` passes.

## Remaining for the mac Testing rollout (follow-on, mirrors Cimian)
1. Release this client build.
2. Update Munki `ReportMateConfig` to inject `REPORTMATE_API_KEY` and write `ApiKey` to the plist (preinstall).
3. Build `ReportMateConfig` to the Testing catalog.