### PR TITLE
Classify built-in panels by connection type, not display name

### DIFF
--- a/Sources/DataCollection/Modules/HardwareModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/HardwareModuleProcessor.swift
@@ -416,10 +416,19 @@ public class HardwareModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
                             displayInfo["manufacture_week"] = Int(mfgWeek) ?? mfgWeek
                         }
                         
-                        // Display type (internal/external) - detect based on name, display_type, and connection
+                        // Display type (internal/external). spdisplays_connection_type is the
+                        // authoritative signal wherever system_profiler reports it: an all-in-one's
+                        // built-in panel says "spdisplays_internal" but is named after the machine
+                        // ("iMac"), so a name-only test types it external and it reaches inventory
+                        // as a standalone monitor. The key is absent on most external displays, so
+                        // the name and display_type heuristics stay as the fallback.
                         let displayName = displayInfo["name"] as? String ?? ""
                         let rawDisplayType = display["spdisplays_display_type"] as? String ?? ""
-                        if displayName.contains("Built-in") || displayName == "Color LCD" || rawDisplayType.contains("built-in") {
+                        let rawConnectionType = display["spdisplays_connection_type"] as? String ?? ""
+                        if rawConnectionType == "spdisplays_internal"
+                            || displayName.contains("Built-in")
+                            || displayName == "Color LCD"
+                            || rawDisplayType.contains("built-in") {
                             displayInfo["type"] = "internal"
                         } else {
                             displayInfo["type"] = "external"


### PR DESCRIPTION
Fixes the all-in-one misclassification tracked as AB#3906, part of the monitor inventory work.

## Problem

`HardwareModuleProcessor` decided internal vs external from the display's name alone:

```swift
if displayName.contains("Built-in") || displayName == "Color LCD" || rawDisplayType.contains("built-in")
```

An iMac's built-in panel is reported by `system_profiler` as `_name: "iMac"`, which matches none of those, so it fell to the `else` branch and was typed `external`. It then looks exactly like a standalone monitor plugged into the machine.

That matters now because the display reconciliation job treats external displays as inventory candidates — these would have been proposed as Snipe-IT assets for monitors that do not exist.

A second effect: `enrichDisplaysWithEDID` only touches external displays lacking a serial, so these panels were eligible to have an unrelated monitor's EDID serial grafted on by fuzzy name match. Typing them correctly removes that exposure.

## Fix

`spdisplays_connection_type` already answers the question, and the value was being parsed into `connection_type` twenty lines earlier. Test it first; keep the name and `display_type` heuristics as the fallback, because the key is absent on most external displays.

## Verification

Build is clean. Checked against every macOS display entry currently in ReportMate:

| connection_type | type | count | effect |
|---|---|---|---|
| internal | internal | 12 | unchanged |
| **internal** | **external** | **11** | **flips to internal** |
| (absent) | external | 153 | unchanged |
| airplay | external | 1 | unchanged |

No genuine external display carries `connection_type=internal`, so the change is confined to the 11 misclassified panels.

Confirmed live on a Mac mini with two Studio Display XDRs that externals are unaffected — both report no `connection_type` and stay external.

The internal path could not be executed on real hardware from here: campus is unreachable without VPN, and this machine has no built-in panel. The raw value is established from the data rather than assumed — the stored `connection_type: "internal"` on those 11 rows is produced only by stripping the `spdisplays_` prefix from `spdisplays_connection_type`. Final confirmation comes when a campus iMac checks in on a build carrying this change.