### PR TITLE
Remove the BTM health check and move full collection overnight

### DIFF
--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -23,7 +23,7 @@ struct ScheduleDefinition {
         .init(label: "Hourly", interval: "Every 60 min", modules: "security, network, management", plistName: "com.github.reportmate.hourly.plist"),
         .init(label: "Fourhourly", interval: "Every 4 hrs", modules: "applications, inventory, system, identity", plistName: "com.github.reportmate.fourhourly.plist"),
         .init(label: "Daily", interval: "9:00 AM", modules: "hardware, peripherals", plistName: "com.github.reportmate.daily.plist"),
-        .init(label: "Full", interval: "Every 12 hrs", modules: "All modules", plistName: "com.github.reportmate.allmodules.plist"),
+        .init(label: "Full", interval: "Daily, 4:00-6:00 AM", modules: "All modules", plistName: "com.github.reportmate.allmodules.plist"),
     ]
 }
 

--- a/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
@@ -3,17 +3,16 @@ import Foundation
 /// Identity module processor - collects user accounts, sessions, and identity management data
 /// Based on MunkiReport patterns for user/account collection
 /// Reference: https://github.com/munkireport/users, https://github.com/munkireport/user_sessions
-/// Collects: local users, group memberships, login sessions, Platform SSO user data,
-///           background task management database health (critical for shared Mac environments)
+/// Collects: local users, group memberships, login sessions, Platform SSO user data
 public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
-    
+
     public init(configuration: ReportMateConfiguration) {
         super.init(moduleId: "identity", configuration: configuration)
     }
-    
+
     public override func collectData() async throws -> ModuleData {
         // Total collection steps for progress tracking
-        let totalSteps = 8
+        let totalSteps = 7
         
         // Collect identity data sequentially with progress tracking
         ConsoleFormatter.writeQueryProgress(queryName: "user_accounts", current: 1, total: totalSteps)
@@ -28,32 +27,27 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         ConsoleFormatter.writeQueryProgress(queryName: "login_history", current: 4, total: totalSteps)
         let loginHistory = try await collectLoginHistory()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "btmdb_health", current: 5, total: totalSteps)
-        let btmdbHealth = try await collectBTMDBHealth()
-        
-        ConsoleFormatter.writeQueryProgress(queryName: "directory_services", current: 6, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "directory_services", current: 5, total: totalSteps)
         let directoryServices = try await collectDirectoryServices()
-        
-        ConsoleFormatter.writeQueryProgress(queryName: "secure_token_users", current: 7, total: totalSteps)
+
+        ConsoleFormatter.writeQueryProgress(queryName: "secure_token_users", current: 6, total: totalSteps)
         let secureTokenUsers = try await collectSecureTokenUsers()
-        
-        ConsoleFormatter.writeQueryProgress(queryName: "platform_sso_users", current: 8, total: totalSteps)
+
+        ConsoleFormatter.writeQueryProgress(queryName: "platform_sso_users", current: 7, total: totalSteps)
         let platformSSOUsers = try await collectPlatformSSOUsers()
-        
+
         // Build identity data dictionary
         let identityData: [String: Any] = [
             "users": userAccounts,
             "groups": groups,
             "loggedInUsers": loggedInUsers,
             "loginHistory": loginHistory,
-            "btmdbHealth": btmdbHealth,
             "directoryServices": directoryServices,
             "secureTokenUsers": secureTokenUsers,
             "platformSSOUsers": platformSSOUsers,
             "summary": buildSummary(
                 users: userAccounts,
-                loggedIn: loggedInUsers,
-                btmdb: btmdbHealth
+                loggedIn: loggedInUsers
             )
         ]
         
@@ -421,121 +415,6 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         return []
     }
     
-    // MARK: - BTM Database Health (Critical for Shared Macs)
-    
-    /// Collects background task management database health metrics
-    /// Critical for shared Mac environments where BTMDB can exceed 4MB limit
-    /// causing loginwindow deadlocks and system freezes
-    private func collectBTMDBHealth() async throws -> [String: Any] {
-        let bashScript = """
-            # Background Task Management Database Health Check
-            # Critical for shared Mac environments (labs, classrooms)
-            # BTMDB can't exceed ~4MB as of macOS Tahoe - causes loginwindow deadlocks
-            
-            btmdb_path="/private/var/db/com.apple.backgroundtaskmanagement"
-            
-            # Get database size - the physical directory may be empty on modern macOS
-            # because the actual data is managed by the system. Use sfltool output
-            # size as a proxy for the effective database size.
-            db_size_bytes=0
-            db_size_mb="0.00"
-            db_exists=false
-            
-            if [ -d "$btmdb_path" ]; then
-                db_exists=true
-                
-                # First try file-based size (traditional approach)
-                raw_size=$(find "$btmdb_path" -type f -exec stat -f%z {} + 2>/dev/null | awk '{s+=$1} END {print s+0}')
-                file_size_bytes=$((${raw_size:-0} + 0))
-                
-                # If directory is empty, use sfltool dumpbtm output size as proxy
-                # This represents the actual data managed by the BTM service
-                if [ "$file_size_bytes" -eq 0 ]; then
-                    btm_dump_size=$(sfltool dumpbtm 2>/dev/null | wc -c | tr -d ' ')
-                    db_size_bytes=$((${btm_dump_size:-0} + 0))
-                else
-                    db_size_bytes=$file_size_bytes
-                fi
-                
-                # Calculate MB with awk for reliability (bc may not be available)
-                db_size_mb=$(awk "BEGIN {printf \\"%.2f\\", $db_size_bytes / 1048576}")
-            fi
-            
-            # Determine health status based on size thresholds
-            # Warning: 3MB, Critical: 3.5MB, Failure likely: 4MB+
-            status="healthy"
-            status_message="Database size within normal limits"
-            
-            if [ "$db_size_bytes" -gt 4194304 ] 2>/dev/null; then
-                status="critical"
-                status_message="Database exceeds 4MB - loginwindow deadlocks likely"
-            elif [ "$db_size_bytes" -gt 3670016 ] 2>/dev/null; then
-                status="critical"
-                status_message="Database exceeds 3.5MB - approaching failure threshold"
-            elif [ "$db_size_bytes" -gt 3145728 ] 2>/dev/null; then
-                status="warning"
-                status_message="Database exceeds 3MB - monitoring recommended"
-            fi
-            
-            # Count jetsam kills in last 7 days (backgroundtaskmanagementd memory limit exceeded)
-            jetsam_count=0
-            last_jetsam=""
-            
-            jetsam_output=$(log show --predicate 'eventMessage CONTAINS "backgroundtaskmanagementd" AND eventMessage CONTAINS "jetsam reason per-process-limit"' --style syslog --info --last 7d 2>/dev/null || echo "")
-            
-            if [ -n "$jetsam_output" ]; then
-                raw_jetsam_count=$(echo "$jetsam_output" | grep -c "jetsam reason per-process-limit" 2>/dev/null || echo "0")
-                # Ensure it's a valid integer
-                jetsam_count=$((raw_jetsam_count + 0))
-                last_jetsam=$(echo "$jetsam_output" | tail -1 | awk '{print $1, $2}' || echo "")
-            fi
-            
-            # If high jetsam count, escalate status
-            if [ "$jetsam_count" -gt 100 ] 2>/dev/null && [ "$status" = "healthy" ]; then
-                status="warning"
-                status_message="High backgroundtaskmanagementd jetsam kill rate ($jetsam_count in 7 days)"
-            elif [ "$jetsam_count" -gt 200 ] 2>/dev/null; then
-                status="critical"
-                status_message="Critical backgroundtaskmanagementd instability ($jetsam_count jetsam kills in 7 days)"
-            fi
-            
-            # Get number of registered background items
-            item_count=0
-            if [ -d "$btmdb_path" ]; then
-                raw_item_count=$(sfltool dumpbtm 2>/dev/null | grep -c "Name:" || echo "0")
-                item_count=$((raw_item_count + 0))
-            fi
-            
-            # Get number of local user accounts (correlates with BTM growth)
-            raw_user_count=$(dscl . -list /Users UniqueID 2>/dev/null | awk '$2 >= 500 && $2 < 65534' | wc -l | tr -d ' ')
-            user_count=$((raw_user_count + 0))
-            
-            # Output proper JSON with unquoted booleans and numbers
-            echo "{"
-            echo "  \\"exists\\": $db_exists,"
-            echo "  \\"path\\": \\"$btmdb_path\\","
-            echo "  \\"sizeBytes\\": $db_size_bytes,"
-            echo "  \\"sizeMB\\": $db_size_mb,"
-            echo "  \\"status\\": \\"$status\\","
-            echo "  \\"statusMessage\\": \\"$status_message\\","
-            echo "  \\"jetsamKillsLast7Days\\": $jetsam_count,"
-            echo "  \\"lastJetsamEvent\\": \\"$last_jetsam\\","
-            echo "  \\"registeredItemCount\\": $item_count,"
-            echo "  \\"localUserCount\\": $user_count,"
-            echo "  \\"thresholds\\": {"
-            echo "    \\"warningMB\\": 3.0,"
-            echo "    \\"criticalMB\\": 3.5,"
-            echo "    \\"failureMB\\": 4.0"
-            echo "  }"
-            echo "}"
-        """
-        
-        return try await executeWithFallback(
-            osquery: nil,
-            bash: bashScript
-        )
-    }
-    
     // MARK: - Directory Services
     
     private func collectDirectoryServices() async throws -> [String: Any] {
@@ -742,8 +621,7 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
     
     private func buildSummary(
         users: [[String: Any]],
-        loggedIn: [[String: Any]],
-        btmdb: [String: Any]
+        loggedIn: [[String: Any]]
     ) -> [String: Any] {
         let totalUsers = users.count
         let adminCount = users.filter { ($0["isAdmin"] as? Bool) == true || ($0["is_admin"] as? Bool) == true }.count
@@ -757,15 +635,12 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             return nil
         })
         let loggedInCount = uniqueLoggedInUsers.count
-        
-        let btmdbStatus = btmdb["status"] as? String ?? "unknown"
-        
+
         return [
             "totalUsers": totalUsers,
             "adminUsers": adminCount,
             "disabledUsers": disabledCount,
-            "currentlyLoggedIn": loggedInCount,
-            "btmdbStatus": btmdbStatus
+            "currentlyLoggedIn": loggedInCount
         ]
     }
 }

--- a/Sources/Models/Modules/IdentityModels.swift
+++ b/Sources/Models/Modules/IdentityModels.swift
@@ -8,7 +8,6 @@ public struct IdentityInfo: Codable, Sendable {
     public let groups: [UserGroup]
     public let loggedInUsers: [LoggedInUser]
     public let loginHistory: [LoginHistoryEntry]
-    public let btmdbHealth: BTMDBHealth
     public let directoryServices: DirectoryServicesInfo
     public let secureTokenUsers: SecureTokenInfo
     public let platformSSOUsers: PlatformSSOUsersInfo
@@ -19,7 +18,6 @@ public struct IdentityInfo: Codable, Sendable {
         groups: [UserGroup] = [],
         loggedInUsers: [LoggedInUser] = [],
         loginHistory: [LoginHistoryEntry] = [],
-        btmdbHealth: BTMDBHealth = BTMDBHealth(),
         directoryServices: DirectoryServicesInfo = DirectoryServicesInfo(),
         secureTokenUsers: SecureTokenInfo = SecureTokenInfo(),
         platformSSOUsers: PlatformSSOUsersInfo = PlatformSSOUsersInfo(),
@@ -29,7 +27,6 @@ public struct IdentityInfo: Codable, Sendable {
         self.groups = groups
         self.loggedInUsers = loggedInUsers
         self.loginHistory = loginHistory
-        self.btmdbHealth = btmdbHealth
         self.directoryServices = directoryServices
         self.secureTokenUsers = secureTokenUsers
         self.platformSSOUsers = platformSSOUsers
@@ -196,73 +193,6 @@ public struct LoginHistoryEntry: Codable, Sendable, Identifiable {
     }
 }
 
-// MARK: - BTMDB Health
-
-/// Background Task Management Database health status
-/// Critical for shared Mac environments where BTMDB corruption causes loginwindow deadlocks
-public struct BTMDBHealth: Codable, Sendable {
-    public let exists: Bool
-    public let path: String
-    public let sizeBytes: Int64
-    public let sizeMB: Double
-    public let status: BTMDBStatus
-    public let statusMessage: String
-    public let jetsamKillsLast7Days: Int
-    public let lastJetsamEvent: String?
-    public let registeredItemCount: Int
-    public let localUserCount: Int
-    public let thresholds: BTMDBThresholds
-    
-    public init(
-        exists: Bool = false,
-        path: String = "/private/var/db/com.apple.backgroundtaskmanagement",
-        sizeBytes: Int64 = 0,
-        sizeMB: Double = 0.0,
-        status: BTMDBStatus = .healthy,
-        statusMessage: String = "Database not found or not accessible",
-        jetsamKillsLast7Days: Int = 0,
-        lastJetsamEvent: String? = nil,
-        registeredItemCount: Int = 0,
-        localUserCount: Int = 0,
-        thresholds: BTMDBThresholds = BTMDBThresholds()
-    ) {
-        self.exists = exists
-        self.path = path
-        self.sizeBytes = sizeBytes
-        self.sizeMB = sizeMB
-        self.status = status
-        self.statusMessage = statusMessage
-        self.jetsamKillsLast7Days = jetsamKillsLast7Days
-        self.lastJetsamEvent = lastJetsamEvent
-        self.registeredItemCount = registeredItemCount
-        self.localUserCount = localUserCount
-        self.thresholds = thresholds
-    }
-}
-
-public enum BTMDBStatus: String, Codable, Sendable {
-    case healthy = "healthy"
-    case warning = "warning"
-    case critical = "critical"
-    case unknown = "unknown"
-}
-
-public struct BTMDBThresholds: Codable, Sendable {
-    public let warningMB: Double
-    public let criticalMB: Double
-    public let failureMB: Double
-    
-    public init(
-        warningMB: Double = 3.0,
-        criticalMB: Double = 3.5,
-        failureMB: Double = 4.0
-    ) {
-        self.warningMB = warningMB
-        self.criticalMB = criticalMB
-        self.failureMB = failureMB
-    }
-}
-
 // MARK: - Directory Services
 
 /// Directory service binding information
@@ -379,19 +309,16 @@ public struct IdentitySummary: Codable, Sendable {
     public let adminUsers: Int
     public let disabledUsers: Int
     public let currentlyLoggedIn: Int
-    public let btmdbStatus: String
-    
+
     public init(
         totalUsers: Int = 0,
         adminUsers: Int = 0,
         disabledUsers: Int = 0,
-        currentlyLoggedIn: Int = 0,
-        btmdbStatus: String = "unknown"
+        currentlyLoggedIn: Int = 0
     ) {
         self.totalUsers = totalUsers
         self.adminUsers = adminUsers
         self.disabledUsers = disabledUsers
         self.currentlyLoggedIn = currentlyLoggedIn
-        self.btmdbStatus = btmdbStatus
     }
 }

--- a/build.sh
+++ b/build.sh
@@ -903,7 +903,11 @@ EOF
 </plist>
 EOF
 
-    # All-modules daemon - full collection every 12 hours
+    # All-modules daemon - full collection once daily in the 04:00-06:00 window.
+    # Full collection is expensive, so it must not run on a rolling StartInterval
+    # that drifts into working hours. launchd has no native trigger jitter, so the
+    # job is wrapped in a short shell that sleeps a random slice of the window;
+    # that spreads the fleet instead of every device hitting the API at 04:00.
     cat > "$APP_LAUNCHDAEMONS/com.github.reportmate.allmodules.plist" << 'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -913,10 +917,17 @@ EOF
     <string>com.github.reportmate.allmodules</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Applications/Utilities/ReportMate.app/Contents/MacOS/managedreportsrunner</string>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>sleep $(/usr/bin/jot -r 1 0 7200); exec /Applications/Utilities/ReportMate.app/Contents/MacOS/managedreportsrunner</string>
     </array>
-    <key>StartInterval</key>
-    <integer>43200</integer>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>4</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>
@@ -1007,9 +1018,10 @@ EOF
     },
     "allmodules": {
       "modules": "all",
-      "interval_seconds": 43200,
+      "calendar_interval": {"hour": 4, "minute": 0},
+      "random_delay_seconds": 7200,
       "launchd_label": "com.github.reportmate.allmodules",
-      "description": "Full collection of all modules every 12 hours"
+      "description": "Full collection of all modules once daily, spread randomly across the 04:00-06:00 maintenance window"
     }
   },
   "version": "1.0.0",


### PR DESCRIPTION
## Why

Traced a recurring "the Mac goes slow for half an hour" complaint to ReportMate itself.

The identity module's BTM database health check shelled out to:

```
log show --predicate 'eventMessage CONTAINS "backgroundtaskmanagementd" AND eventMessage CONTAINS "jetsam reason per-process-limit"' --style syslog --info --last 7d
```

A `CONTAINS` predicate over `--last 7d` decompresses and string-scans the whole unified log archive. On a machine with a 2.7 GB log store that pegged a core for **25-30+ minutes**, and dragged `logd` along with it. The `Nice = 10` on the LaunchDaemon bought nothing, because the expensive work happens inside `logd`, which isn't niced.

`identity` is in the **fourhourly** job, so this ran every four hours on every Mac in the fleet.

Observed on mac-desktop: load average 10-14 on 14 cores while the CPU was still ~64% idle — pure I/O and daemon contention.

## What changed

**Removed the BTM check outright.** The BTM 4 MB / loginwindow-deadlock problem this guarded against is no longer live, so it's deleted rather than made cheaper — collector, `BTMDBHealth` / `BTMDBStatus` / `BTMDBThresholds` models, the `btmdbHealth` payload key, and the `btmdbStatus` summary field. No `btmdb` references remain in `Sources/`.

**Moved `allmodules` into an overnight window.** It used `StartInterval 43200`, which counts from completion rather than wall-clock, so the run drifts — today it started at 15:59, mid-working-day, for the most expensive collection there is. Now `StartCalendarInterval` at 04:00.

launchd has no trigger jitter, so the job is wrapped in a short shell that sleeps a random slice of a two-hour window before `exec`ing the runner. That spreads the fleet across 04:00-06:00 instead of every device hitting the API at 04:00 sharp. Happy to swap this for a flat 04:00 if the wrapper isn't wanted.

Also corrected the Settings UI, which still advertised "Every 12 hrs".

## Downstream note

`reportmate-api` (`routers/fleet.py`, `sql/devices/bulk_identity.sql`) and `reportmate-app-web` (`app/identity/page.tsx`, `IdentityTab.tsx`, `modules/identity.ts`) still reference `btmdb`. They'll now receive no `btmdbHealth` key. Nothing breaks, but the dashboard will show an empty BTM section until those are cleaned up — worth a follow-up. `reportmate-client-win` never had BTM code.

## Verification

- `swift build` clean on both the `ReportMate` and `App` targets
- `plutil -lint` OK on the generated allmodules plist; `StartCalendarInterval` and the wrapped `ProgramArguments` verified via `PlistBuddy`
- `jot -r 1 0 7200` confirmed present and returning sane values under `/bin/sh`

Not yet deployed to any device — the fleet still runs the old client.