### PR TITLE
Use a placeholder API URL in the build usage example

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -128,7 +128,7 @@ EXAMPLES:
     $0 --sign --install
 
     # Build specific version with API URL
-    $0 --version "2025.11.30" --api-url "https://reportmate.ecuad.ca"
+    $0 --version "2025.11.30" --api-url "https://reportmate.example.edu"
 
     # Create release
     $0 --notarize --create-tag --create-release


### PR DESCRIPTION
The `--api-url` example in `build.sh`'s usage text used our production endpoint, so copying it built a client that reports into **our** fleet.

```diff
-    $0 --version "2025.11.30" --api-url "https://reportmate.ecuad.ca"
+    $0 --version "2025.11.30" --api-url "https://reportmate.example.edu"
```

Verified `build.sh` still passes `bash -n`. No occurrence of `ecuad` remains in this repo.

AB#3946