### PR TITLE
Rename app to Managed Reports Runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
             printf '%s\n' '```bash'
             printf '%s\n' 'codesign --force --options runtime --timestamp \'
             printf '%s\n' '  --sign "Developer ID Application: <Org> (<TeamID>)" \'
-            printf '%s\n' '  /Applications/Utilities/ReportMate.app'
+            printf '%s\n' '  "/Applications/Utilities/Managed Reports Runner.app"'
             printf '%s\n' ''
             printf '%s\n' 'productsign --timestamp \'
             printf '%s\n' '  --sign "Developer ID Installer: <Org> (<TeamID>)" \'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Available modules: `hardware`, `system`, `network`, `security`, `applications`, 
 
 - `build.sh` generates `AppVersion.swift` with the version at build time and restores placeholder on exit
 - Signing requires `.env` file with `SIGNING_IDENTITY_APP` and `SIGNING_IDENTITY_INSTALLER`
-- PKG installer creates an app bundle at `/Applications/Utilities/ReportMate.app`
+- PKG installer creates an app bundle at `/Applications/Utilities/Managed Reports Runner.app`
 - CLI binary and GUI binary both live in `Contents/MacOS/`
 - A wrapper at `/usr/local/reportmate/managedreportsrunner` forwards to the app bundle CLI
 - LaunchDaemons are embedded in the app bundle and installed by postinstall script

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -23,7 +23,7 @@ struct ScheduleDefinition {
         .init(label: "Hourly", interval: "Every 60 min", modules: "security, network, management", plistName: "com.github.reportmate.hourly.plist"),
         .init(label: "Fourhourly", interval: "Every 4 hrs", modules: "applications, inventory, system, identity", plistName: "com.github.reportmate.fourhourly.plist"),
         .init(label: "Daily", interval: "9:00 AM", modules: "hardware, peripherals", plistName: "com.github.reportmate.daily.plist"),
-        .init(label: "Full", interval: "Every 12 hrs", modules: "All modules", plistName: "com.github.reportmate.allmodules.plist"),
+        .init(label: "Full", interval: "Daily, 4:00-6:00 AM", modules: "All modules", plistName: "com.github.reportmate.allmodules.plist"),
     ]
 }
 

--- a/Sources/App/Views/SettingsView.swift
+++ b/Sources/App/Views/SettingsView.swift
@@ -51,7 +51,7 @@ struct SettingsView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 56, height: 56)
-                    Text("ReportMate")
+                    Text("Managed Reports Runner")
                         .font(.title2.bold())
                     Text("Device telemetry collection & reporting")
                         .font(.caption)

--- a/Sources/Core/Services/APIClient.swift
+++ b/Sources/Core/Services/APIClient.swift
@@ -34,6 +34,32 @@ public class APIClient {
     }
     
     /// Transmit device data to the API
+    /// Copy the payload's device identity onto the request as headers.
+    ///
+    /// Identity is diagnostic metadata, so an unusable value is skipped rather
+    /// than allowed to cost the device its check-in: URLRequest rejects header
+    /// values carrying control characters, and hardware and directory lookups
+    /// occasionally return them.
+    private func applyIdentityHeaders(to request: inout URLRequest, from payload: [String: Any]) {
+        guard let metadata = payload["metadata"] as? [String: Any] else { return }
+        let additional = metadata["additional"] as? [String: Any]
+        let fields: [(String, Any?)] = [
+            ("X-Device-Serial", metadata["serialNumber"]),
+            ("X-Device-Uuid", metadata["deviceId"]),
+            ("X-Device-Name", additional?["deviceName"]),
+            ("X-Platform", metadata["platform"]),
+            ("X-Client-Version", metadata["clientVersion"])
+        ]
+        for (header, value) in fields {
+            guard let raw = value as? String else { continue }
+            let cleaned = String(String.UnicodeScalarView(
+                raw.unicodeScalars.filter { $0.value >= 32 && $0.value < 127 }
+            )).trimmingCharacters(in: .whitespaces)
+            guard !cleaned.isEmpty else { continue }
+            request.setValue(String(cleaned.prefix(255)), forHTTPHeaderField: header)
+        }
+    }
+
     public func transmitData(_ payload: [String: Any]) async throws -> Result<TransmissionResponse, APIError> {
         guard let apiUrl = configuration.apiUrl,
               let url = URL(string: apiUrl) else {
@@ -54,7 +80,15 @@ public class APIClient {
         if let passphrase = configuration.passphrase {
             request.setValue(passphrase, forHTTPHeaderField: "X-Client-Passphrase")
         }
-        
+
+        // Mirror the device's identity into headers. The same values sit in the
+        // payload, but the server can only read them when the body arrives
+        // intact and parses; a truncated or aborted upload is rejected with no
+        // idea which machine sent it and lands in /events/failures as
+        // "unidentified", which is a rejection nobody can act on. Headers
+        // survive a body that never became readable.
+        applyIdentityHeaders(to: &request, from: payload)
+
         do {
             // Encode as JSON dictionary
             request.httpBody = try JSONSerialization.data(withJSONObject: payload)

--- a/Sources/Core/Services/BashService.swift
+++ b/Sources/Core/Services/BashService.swift
@@ -3,44 +3,40 @@ import Foundation
 /// Bash command execution service for fallback data collection
 public class BashService {
     
-    /// Execute a bash command and return output
-    public static func execute(_ command: String) async throws -> String {
-        return try await withCheckedThrowingContinuation { continuation in
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/bin/bash")
-            task.arguments = ["-c", command]
-            
-            let outputPipe = Pipe()
-            let errorPipe = Pipe()
-            task.standardOutput = outputPipe
-            task.standardError = errorPipe
-            
-            do {
-                try task.run()
-                
-                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-                let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-                
-                task.waitUntilExit()
-                
-                if task.terminationStatus != 0 {
-                    let errorMessage = String(data: errorData, encoding: .utf8) ?? "Unknown error"
-                    continuation.resume(throwing: BashError.executionFailed(command, errorMessage))
-                    return
-                }
-                
-                let output = String(data: outputData, encoding: .utf8) ?? ""
-                continuation.resume(returning: output)
-                
-            } catch {
-                continuation.resume(throwing: BashError.processLaunchFailed(error))
-            }
+    /// Execute a bash command and return its standard output.
+    ///
+    /// Every command runs under a hard time budget. Without one, a single wedged external tool
+    /// stalls the whole collection silently and indefinitely: the module never reports, the
+    /// payload never ships, and the device simply goes quiet while the other daemons keep
+    /// running normally. That is far harder to spot than a crash. Observed in the wild with
+    /// `mdatp health` against a hung Defender daemon, which held two collection runs for
+    /// thirty minutes and nearly six hours respectively.
+    ///
+    /// - Parameter timeout: seconds before the command is terminated. Raise it for commands
+    ///   that are legitimately slow rather than removing the bound.
+    public static func execute(
+        _ command: String,
+        timeout: TimeInterval = ProcessRunner.defaultTimeout
+    ) async throws -> String {
+        let result = try await ProcessRunner.bash(command, timeout: timeout)
+
+        if result.timedOut {
+            throw BashError.timedOut(command, timeout)
         }
+
+        if result.exitCode != 0 {
+            let message = result.standardError.isEmpty ? "Unknown error" : result.standardError
+            throw BashError.executionFailed(command, message)
+        }
+
+        return result.standardOutput
     }
-    
+
     /// Execute system_profiler command for hardware information
     public static func executeSystemProfiler(_ dataType: String) async throws -> [String: Any] {
-        let output = try await execute("system_profiler \(dataType) -json")
+        // system_profiler is legitimately slow on large data types, so it gets a wider budget
+        // than the default - but still a bounded one.
+        let output = try await execute("system_profiler \(dataType) -json", timeout: 300)
         
         guard let jsonData = output.data(using: .utf8),
               let jsonObject = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
@@ -55,7 +51,8 @@ public enum BashError: Error, LocalizedError {
     case executionFailed(String, String)
     case processLaunchFailed(Error)
     case invalidOutput(String)
-    
+    case timedOut(String, TimeInterval)
+
     public var errorDescription: String? {
         switch self {
         case .executionFailed(let command, let error):
@@ -64,6 +61,8 @@ public enum BashError: Error, LocalizedError {
             return "Failed to launch bash process: \(error.localizedDescription)"
         case .invalidOutput(let message):
             return "Invalid bash output: \(message)"
+        case .timedOut(let command, let seconds):
+            return "Bash command exceeded its \(Int(seconds))s budget and was terminated: '\(command)'"
         }
     }
 }

--- a/Sources/Core/Services/ProcessRunner.swift
+++ b/Sources/Core/Services/ProcessRunner.swift
@@ -1,0 +1,264 @@
+import Foundation
+
+/// Result of a bounded external process run.
+public struct ProcessRunResult: Sendable {
+    public let standardOutput: String
+    public let standardError: String
+    public let exitCode: Int32
+    /// True when the process was killed because it exceeded its time budget.
+    public let timedOut: Bool
+}
+
+/// Runs external processes under a hard time budget.
+///
+/// Two properties matter, and the obvious implementation has neither:
+///
+/// 1. **Output is drained concurrently.** Reading stdout to EOF and only then reading stderr
+///    deadlocks whenever a command writes more than a pipe buffer (64 KB) to stderr: the child
+///    blocks writing stderr, the parent blocks reading stdout, and neither moves. That is a hang
+///    with no misbehaving command involved at all.
+///
+/// 2. **The timeout does not depend on EOF.** A command launched as `/bin/bash -c "..."` passes
+///    its inherited pipe to its own children, so killing bash alone does not close the write end
+///    — a wedged grandchild keeps it open and a blocking read waits forever. This drains through
+///    readability handlers and resolves the timeout independently, so a surviving grandchild can
+///    delay cleanup but can never stall collection.
+///
+/// Best-effort teardown then walks the process tree, because killing only the direct child
+/// leaves the grandchild that actually wedged still running.
+public enum ProcessRunner {
+
+    /// Default budget for a single external command. Individual collectors may pass more when a
+    /// command is legitimately slow; nothing should run unbounded.
+    public static let defaultTimeout: TimeInterval = 180
+
+    /// Grace period between SIGTERM and SIGKILL, matching the osquery runner.
+    private static let terminationGracePeriod: TimeInterval = 2
+
+    public static func run(
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval = defaultTimeout,
+        label: String? = nil
+    ) async throws -> ProcessRunResult {
+        let description = label ?? ([executable] + arguments).joined(separator: " ")
+        let box = ProcessBox()
+
+        return try await withThrowingTaskGroup(of: RunOutcome.self) { group in
+            group.addTask {
+                let result = try await runToCompletion(
+                    executable: executable,
+                    arguments: arguments,
+                    box: box
+                )
+                return .completed(result)
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                return .timedOut
+            }
+
+            defer { group.cancelAll() }
+
+            while let outcome = try await group.next() {
+                switch outcome {
+                case .completed(let result):
+                    return result
+
+                case .timedOut:
+                    ConsoleFormatter.writeDebug(
+                        "Command exceeded its \(Int(timeout))s budget, terminating: \(description)"
+                    )
+                    box.terminate()
+                    try? await Task.sleep(nanoseconds: UInt64(terminationGracePeriod * 1_000_000_000))
+                    box.forceKillTree()
+
+                    // Report rather than throw. A timed-out collector should degrade to an empty
+                    // result like any other failure, not abort the module around it.
+                    return ProcessRunResult(
+                        standardOutput: box.drainedOutput(),
+                        standardError: box.drainedError(),
+                        exitCode: -1,
+                        timedOut: true
+                    )
+                }
+            }
+
+            return ProcessRunResult(standardOutput: "", standardError: "", exitCode: -1, timedOut: false)
+        }
+    }
+
+    /// Convenience for the overwhelmingly common `/bin/bash -c` case.
+    public static func bash(
+        _ command: String,
+        timeout: TimeInterval = defaultTimeout
+    ) async throws -> ProcessRunResult {
+        try await run(
+            executable: "/bin/bash",
+            arguments: ["-c", command],
+            timeout: timeout,
+            label: command
+        )
+    }
+
+    private enum RunOutcome {
+        case completed(ProcessRunResult)
+        case timedOut
+    }
+
+    private static func runToCompletion(
+        executable: String,
+        arguments: [String],
+        box: ProcessBox
+    ) async throws -> ProcessRunResult {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: executable)
+            task.arguments = arguments
+
+            let outputPipe = Pipe()
+            let errorPipe = Pipe()
+            task.standardOutput = outputPipe
+            task.standardError = errorPipe
+
+            // Drain both pipes as data arrives. Nothing here blocks, so neither stream can
+            // back-pressure the other into a deadlock.
+            outputPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if !data.isEmpty { box.appendOutput(data) }
+            }
+            errorPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if !data.isEmpty { box.appendError(data) }
+            }
+
+            task.terminationHandler = { finished in
+                // Collect whatever is still buffered before tearing the handlers down.
+                let remainingOut = outputPipe.fileHandleForReading.availableData
+                if !remainingOut.isEmpty { box.appendOutput(remainingOut) }
+                let remainingErr = errorPipe.fileHandleForReading.availableData
+                if !remainingErr.isEmpty { box.appendError(remainingErr) }
+
+                outputPipe.fileHandleForReading.readabilityHandler = nil
+                errorPipe.fileHandleForReading.readabilityHandler = nil
+
+                guard box.claimCompletion() else { return }
+                continuation.resume(returning: ProcessRunResult(
+                    standardOutput: box.drainedOutput(),
+                    standardError: box.drainedError(),
+                    exitCode: finished.terminationStatus,
+                    timedOut: false
+                ))
+            }
+
+            do {
+                try task.run()
+                box.attach(task)
+            } catch {
+                outputPipe.fileHandleForReading.readabilityHandler = nil
+                errorPipe.fileHandleForReading.readabilityHandler = nil
+                guard box.claimCompletion() else { return }
+                continuation.resume(throwing: BashError.processLaunchFailed(error))
+            }
+        }
+    }
+}
+
+/// Shared handle to a running Process plus its accumulated output, so the timeout path can kill
+/// it and read what it managed to produce from outside the task that launched it. Process is not
+/// Sendable across concurrency boundaries, hence the lock-guarded wrapper.
+final class ProcessBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var outputData = Data()
+    private var errorData = Data()
+    private var completionClaimed = false
+
+    func attach(_ process: Process) {
+        lock.lock(); defer { lock.unlock() }
+        self.process = process
+    }
+
+    func appendOutput(_ data: Data) {
+        lock.lock(); defer { lock.unlock() }
+        outputData.append(data)
+    }
+
+    func appendError(_ data: Data) {
+        lock.lock(); defer { lock.unlock() }
+        errorData.append(data)
+    }
+
+    func drainedOutput() -> String {
+        lock.lock(); defer { lock.unlock() }
+        return String(data: outputData, encoding: .utf8) ?? ""
+    }
+
+    func drainedError() -> String {
+        lock.lock(); defer { lock.unlock() }
+        return String(data: errorData, encoding: .utf8) ?? ""
+    }
+
+    /// Ensures the continuation is resumed exactly once across the completion and timeout paths.
+    func claimCompletion() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if completionClaimed { return false }
+        completionClaimed = true
+        return true
+    }
+
+    func terminate() {
+        lock.lock(); defer { lock.unlock() }
+        guard let process = process, process.isRunning else { return }
+        process.terminate()
+    }
+
+    /// SIGKILL the process and every descendant. Killing only the direct child leaves the
+    /// grandchild that actually wedged holding the inherited pipe.
+    func forceKillTree() {
+        lock.lock()
+        let pid = (process?.isRunning == true) ? process?.processIdentifier : nil
+        lock.unlock()
+        guard let pid = pid else { return }
+
+        for descendant in Self.descendants(of: pid).reversed() {
+            kill(descendant, SIGKILL)
+        }
+        kill(pid, SIGKILL)
+    }
+
+    /// Breadth-first walk of the process tree via pgrep, deepest last.
+    private static func descendants(of pid: pid_t, depth: Int = 0) -> [pid_t] {
+        guard depth < 8 else { return [] }
+        let children = pgrepChildren(of: pid)
+        var all: [pid_t] = []
+        for child in children {
+            all.append(child)
+            all.append(contentsOf: descendants(of: child, depth: depth + 1))
+        }
+        return all
+    }
+
+    private static func pgrepChildren(of pid: pid_t) -> [pid_t] {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        task.arguments = ["-P", String(pid)]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = FileHandle.nullDevice
+
+        do {
+            try task.run()
+        } catch {
+            return []
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+
+        return (String(data: data, encoding: .utf8) ?? "")
+            .split(separator: "\n")
+            .compactMap { pid_t($0.trimmingCharacters(in: .whitespaces)) }
+    }
+}

--- a/Sources/DataCollection/Modules/ApplicationsModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/ApplicationsModuleProcessor.swift
@@ -350,13 +350,26 @@ public class ApplicationsModuleProcessor: BaseModuleProcessor, @unchecked Sendab
                 echo "{\\"name\\": \\"$label_escaped\\", \\"path\\": \\"$program_escaped\\", \\"type\\": \\"LaunchAgent\\", \\"source\\": \\"Local\\", \\"status\\": \\"$status\\"},"
             done
             
-            # Get Login Items via osascript (if available)
-            osascript -e 'tell application "System Events" to get the name of every login item' 2>/dev/null | tr ',' '\\n' | while read -r item; do
-                item=$(echo "$item" | xargs)
-                [ -z "$item" ] && continue
-                item_escaped=$(echo "$item" | sed 's/"/\\\\"/g')
-                echo "{\\"name\\": \\"$item_escaped\\", \\"path\\": \\"\\", \\"type\\": \\"LoginItem\\", \\"source\\": \\"User\\", \\"status\\": \\"Enabled\\"},"
-            done
+            # Get Login Items from BackgroundTaskManagement (sfltool, root only - no Apple Events / TCC prompt)
+            if [ "$(id -u)" -eq 0 ]; then
+                sfltool dumpbtm 2>/dev/null | awk '
+                    function emit() {
+                        if (type ~ /login item/ && name != "" && name != "(null)") {
+                            status = (disp ~ /enabled/) ? "Enabled" : "Disabled"
+                            gsub(/"/, "", name); gsub(/"/, "", url)
+                            sub(/^file:\\/\\//, "", url); sub(/\\/$/, "", url)
+                            printf "{\\"name\\": \\"%s\\", \\"path\\": \\"%s\\", \\"type\\": \\"LoginItem\\", \\"source\\": \\"User\\", \\"status\\": \\"%s\\"},\\n", name, url, status
+                        }
+                        name=""; type=""; disp=""; url=""
+                    }
+                    /^[[:space:]]*#[0-9]+:/ { emit() }
+                    /^[[:space:]]*Name:/ { name=$0; sub(/^[[:space:]]*Name:[[:space:]]*/, "", name) }
+                    /^[[:space:]]*Type:/ { type=$0 }
+                    /^[[:space:]]*Disposition:/ { disp=$0 }
+                    /^[[:space:]]*URL:/ { url=$0; sub(/^[[:space:]]*URL:[[:space:]]*/, "", url) }
+                    END { emit() }
+                '
+            fi
             
             echo "{}]" | sed 's/,{}]/]/'
         """

--- a/Sources/DataCollection/Modules/HardwareModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/HardwareModuleProcessor.swift
@@ -2561,47 +2561,36 @@ private func collectBatteryInfo() async throws -> [String: Any] {
     /// Use this for user home directories which can contain millions of files
     /// Includes timeout to prevent hanging on TCC-protected directories
     private func fastDirectorySizeWithDu(path: String, timeoutSeconds: Int = 30) async -> Int64? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/du")
-        // -s = summary only, -k = kilobytes, -x = don't cross filesystem boundaries
-        process.arguments = ["-skx", path]
-        
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()  // Suppress error output (permission denied, etc.)
-        
-        do {
-            try process.run()
-            
-            // Wait with timeout to prevent hanging on TCC-protected directories
-            let deadline = Date().addingTimeInterval(Double(timeoutSeconds))
-            while process.isRunning && Date() < deadline {
-                try await Task.sleep(nanoseconds: 100_000_000)  // 100ms
-            }
-            
-            if process.isRunning {
-                // Timeout reached - terminate the process
-                print("[\(timestamp())] du timeout for: \(path) - terminating")
-                process.terminate()
-                return nil
-            }
-            
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            if let output = String(data: data, encoding: .utf8) {
-                // Output format: "123456\t/path/to/directory"
-                let components = output.components(separatedBy: "\t")
-                if let sizeStr = components.first?.trimmingCharacters(in: .whitespacesAndNewlines),
-                   let sizeKB = Int64(sizeStr) {
-                    return sizeKB * 1024  // Convert KB to bytes
-                }
-            }
-        } catch {
-            if process.isRunning {
-                process.terminate()
-            }
+        // -s = summary only, -k = kilobytes, -x = don't cross filesystem boundaries.
+        // stderr is discarded by the caller: du reports permission-denied per directory and
+        // that noise is expected here.
+        //
+        // Previously this polled `process.isRunning` every 100ms against a deadline and then
+        // read the pipe. The poll bounded the wait but terminating du does not close a pipe
+        // still held open by anything it spawned, and the read that followed was unbounded —
+        // so the timeout path could still block. ProcessRunner resolves the timeout without
+        // depending on EOF and kills the whole process tree.
+        let result = try? await ProcessRunner.run(
+            executable: "/usr/bin/du",
+            arguments: ["-skx", path],
+            timeout: TimeInterval(timeoutSeconds),
+            label: "du -skx \(path)"
+        )
+
+        guard let result = result else { return nil }
+
+        if result.timedOut {
+            ConsoleFormatter.writeDebug("du exceeded its \(timeoutSeconds)s budget for: \(path)")
             return nil
         }
-        
+
+        // Output format: "123456\t/path/to/directory"
+        let components = result.standardOutput.components(separatedBy: "\t")
+        if let sizeStr = components.first?.trimmingCharacters(in: .whitespacesAndNewlines),
+           let sizeKB = Int64(sizeStr) {
+            return sizeKB * 1024  // Convert KB to bytes
+        }
+
         return nil
     }
     

--- a/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
@@ -638,100 +638,314 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
     
     // MARK: - Platform SSO Users (user-level SSO registration status)
     
-    /// Collects Platform SSO user registration status
-    /// This focuses on per-user SSO registration, complementing the device-level config in Security module
+    /// Collects Platform SSO per-user registration and token state.
+    ///
+    /// `app-sso platform -s` prints four sections: a device-level `Device Configuration`
+    /// block, a `Login Configuration` block, a per-user `User Configuration` block, and a
+    /// plain-text `SSO Tokens` trailer. Two properties of that output drive this collector:
+    ///
+    /// 1. `registrationCompleted` is device-level. It prints identically for every account,
+    ///    including accounts that have never registered, so it can never be used to decide
+    ///    whether a *user* is registered. Per-user truth is a populated `User Configuration`
+    ///    block, and the token state is the `SSO Tokens` trailer.
+    /// 2. Platform SSO state is only reachable inside the user's Aqua session. Probing a user
+    ///    with no GUI session blocks indefinitely, so every account is gated on an active
+    ///    `gui/<uid>` launchd domain and every invocation carries a hard timeout.
     private func collectPlatformSSOUsers() async throws -> [String: Any] {
         let bashScript = """
-            # Platform SSO user registration status (macOS 13+ Ventura)
-            # Focuses on per-user SSO registration for Identity module
-            
-            # Check macOS version (Platform SSO requires 13+)
-            os_version=$(sw_vers -productVersion | cut -d. -f1)
-            if [ "$os_version" -lt 13 ]; then
+            # Platform SSO per-user registration and token state (macOS 13+ Ventura)
+            set -m
+
+            APPSSO="/usr/bin/app-sso"
+
+            emit_unsupported() {
                 echo "{"
                 echo "  \\"supported\\": false,"
-                echo "  \\"users\\": []"
-                echo "}"
-                exit 0
-            fi
-            
-            # Get device SSO state to check if Platform SSO is configured
-            sso_state=$(app-sso platform -s 2>/dev/null || echo "")
-            registered="false"
-            
-            if [ -n "$sso_state" ]; then
-                if echo "$sso_state" | grep -q '"registrationCompleted" *: *true'; then
-                    registered="true"
-                fi
-            fi
-            
-            if [ "$registered" != "true" ]; then
-                echo "{"
-                echo "  \\"supported\\": true,"
                 echo "  \\"deviceRegistered\\": false,"
+                echo "  \\"provider\\": \\"\\","
+                echo "  \\"method\\": \\"\\","
+                echo "  \\"extensionIdentifier\\": \\"\\","
+                echo "  \\"organizationName\\": \\"\\","
+                echo "  \\"loginFrequency\\": 0,"
+                echo "  \\"offlineGracePeriod\\": \\"\\","
+                echo "  \\"registeredUserCount\\": 0,"
+                echo "  \\"unregisteredUserCount\\": 0,"
+                echo "  \\"tokenPresentCount\\": 0,"
+                echo "  \\"nonPlatformSSOAccounts\\": [],"
                 echo "  \\"users\\": []"
                 echo "}"
+            }
+
+            os_major=$(sw_vers -productVersion 2>/dev/null | cut -d. -f1)
+            case "$os_major" in
+                ''|*[!0-9]*) emit_unsupported; exit 0 ;;
+            esac
+            if [ "$os_major" -lt 13 ] || [ ! -x "$APPSSO" ]; then
+                emit_unsupported
                 exit 0
             fi
-            
-            # Collect per-user SSO registration status
+
+            # Run a command under a hard wall-clock limit, killing its whole process group on
+            # expiry. app-sso blocks forever against a user with no GUI session, and output is
+            # staged through a temp file so a surviving grandchild can never hold our stdout
+            # pipe open.
+            run_with_timeout() {
+                _limit=$1
+                shift
+                _out=$(mktemp /tmp/reportmate-psso.XXXXXX) || return 1
+                "$@" >"$_out" 2>/dev/null &
+                _pid=$!
+                _waited=0
+                while kill -0 "$_pid" 2>/dev/null; do
+                    if [ "$_waited" -ge "$_limit" ]; then
+                        kill -9 -"$_pid" 2>/dev/null
+                        kill -9 "$_pid" 2>/dev/null
+                        wait "$_pid" 2>/dev/null
+                        rm -f "$_out"
+                        return 124
+                    fi
+                    sleep 1
+                    _waited=$((_waited + 1))
+                done
+                wait "$_pid" 2>/dev/null
+                cat "$_out"
+                rm -f "$_out"
+                return 0
+            }
+
+            # Values here are UPNs, UUIDs, ISO dates and enum strings. None legitimately
+            # contain a quote or backslash once unescaped, so dropping those keeps the
+            # hand-assembled JSON well formed.
+            json_scrub() {
+                printf '%s' "$1" | tr -d '\\\\"' | tr -d '\\r\\n\\t'
+            }
+
+            # First "key" : "value" pair in the text on stdin.
+            json_string() {
+                grep "\\"$1\\"" | head -1 | sed 's/.*: *"\\(.*\\)".*/\\1/'
+            }
+
+            running_uid=$(id -u)
+
+            # --- Device configuration ---------------------------------------------
+            device_state=$(run_with_timeout 20 "$APPSSO" platform -s)
+            device_section=$(printf '%s\\n' "$device_state" | awk '/^Device Configuration:/{f=1;next} f&&/^Login Configuration:/{f=0} f')
+
+            device_registered="false"
+            if printf '%s\\n' "$device_section" | grep -q '"registrationCompleted" *: *true'; then
+                device_registered="true"
+            fi
+
+            extension_id=$(printf '%s\\n' "$device_section" | json_string extensionIdentifier)
+            org_name=$(printf '%s\\n' "$device_section" | json_string accountDisplayName)
+            offline_grace=$(printf '%s\\n' "$device_section" | json_string offlineGracePeriod)
+            login_freq=$(printf '%s\\n' "$device_section" | grep '"loginFrequency"' | head -1 | sed 's/[^0-9]//g')
+            [ -z "$login_freq" ] && login_freq=0
+
+            # Identify the IdP from the extension bundle id, falling back to the account
+            # display name. The extension id is the reliable signal.
+            provider=""
+            case "$extension_id" in
+                *microsoft*|*Microsoft*) provider="Microsoft Entra ID" ;;
+                *okta*|*Okta*)           provider="Okta" ;;
+                *jamf*|*Jamf*)           provider="Jamf Connect" ;;
+                *google*|*Google*)       provider="Google" ;;
+            esac
+            if [ -z "$provider" ]; then
+                case "$org_name" in
+                    *Entra*|*Microsoft*) provider="Microsoft Entra ID" ;;
+                    *Okta*)              provider="Okta" ;;
+                    *Jamf*)              provider="Jamf Connect" ;;
+                    *Google*)            provider="Google" ;;
+                esac
+            fi
+
+            # Device-wide authentication method from the configured login type.
+            device_login_type=$(printf '%s\\n' "$device_section" | json_string loginType)
+            method="Unknown"
+            case "$device_login_type" in
+                *SecureEnclaveKey*) method="Secure enclave key" ;;
+                *SmartCard*)        method="Smart card" ;;
+                *Password*)         method="Password" ;;
+            esac
+
+            # Accounts the PSSO payload exempts by policy. Never probe these: they have no SSO
+            # agent, so app-sso would hang against them.
+            non_psso_accounts=$(printf '%s\\n' "$device_section" \\
+                | sed -n '/"nonPlatformSSOAccounts"/,/]/p' \\
+                | grep -v 'nonPlatformSSOAccounts' \\
+                | sed -n 's/.*"\\([^"]*\\)".*/\\1/p')
+
+            non_psso_json="["
+            first_np="true"
+            for acct in $non_psso_accounts; do
+                [ "$first_np" = "true" ] && first_np="false" || non_psso_json="$non_psso_json,"
+                non_psso_json="$non_psso_json\\"$(json_scrub "$acct")\\""
+            done
+            non_psso_json="$non_psso_json]"
+
+            is_non_psso_account() {
+                for acct in $non_psso_accounts; do
+                    [ "$acct" = "$1" ] && return 0
+                done
+                return 1
+            }
+
+            has_gui_session() {
+                if [ "$running_uid" = "$1" ]; then
+                    return 0
+                fi
+                launchctl print "gui/$1" >/dev/null 2>&1
+            }
+
+            appsso_for_user() {
+                if [ "$running_uid" = "0" ]; then
+                    run_with_timeout 20 launchctl asuser "$2" sudo -u "$1" "$APPSSO" platform -s
+                elif [ "$running_uid" = "$2" ]; then
+                    run_with_timeout 20 "$APPSSO" platform -s
+                else
+                    return 1
+                fi
+            }
+
             users_json="["
             first_user="true"
             registered_count=0
             unregistered_count=0
-            
-            # Get all human users
-            for user in $(dscl . -list /Users | grep -v "^_" | grep -v "daemon\\|nobody\\|root\\|Guest"); do
-                user_home=$(dscl . -read /Users/"$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}' || echo "")
-                if [ ! -d "$user_home" ] || [ "$user_home" = "/var/empty" ]; then
-                    continue
-                fi
-                
-                # Run app-sso as the user to get their SSO status
-                user_sso=$(sudo -u "$user" app-sso platform -s 2>/dev/null || echo "")
-                
-                user_registered="false"
-                user_upn=""
-                last_auth=""
-                
-                if [ -n "$user_sso" ]; then
-                    if echo "$user_sso" | grep -q '"registrationCompleted" *: *true'; then
-                        user_registered="true"
-                        registered_count=$((registered_count + 1))
+            token_count=0
+
+            for user in $(dscl . -list /Users UniqueID 2>/dev/null | awk '$2 >= 500 && $2 < 65534 {print $1}'); do
+                uid=$(dscl . -read "/Users/$user" UniqueID 2>/dev/null | awk '{print $2}')
+                [ -z "$uid" ] && continue
+
+                home=$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}')
+                case "$home" in
+                    ''|/var/empty|/dev/null) continue ;;
+                esac
+
+                registered="false"
+                upn=""
+                login_user_name=""
+                unique_id=""
+                user_state=""
+                login_type=""
+                last_login=""
+                token_received=""
+                token_expiration=""
+                token_expired="null"
+                has_tokens="false"
+                probe_status="ok"
+
+                if is_non_psso_account "$user"; then
+                    probe_status="excluded"
+                elif [ "$device_registered" != "true" ]; then
+                    probe_status="device-not-registered"
+                elif ! has_gui_session "$uid"; then
+                    probe_status="no-session"
+                else
+                    user_output=$(appsso_for_user "$user" "$uid")
+                    if [ $? -ne 0 ] || [ -z "$user_output" ]; then
+                        probe_status="probe-failed"
                     else
-                        unregistered_count=$((unregistered_count + 1))
+                        user_section=$(printf '%s\\n' "$user_output" \\
+                            | awk '/^User Configuration:/{f=1;next} f&&/^SSO Tokens:/{f=0} f')
+                        token_section=$(printf '%s\\n' "$user_output" | sed -n '/^SSO Tokens:/,$p')
+
+                        unique_id=$(printf '%s\\n' "$user_section" | json_string uniqueIdentifier)
+                        user_state=$(printf '%s\\n' "$user_section" | json_string state)
+                        login_type=$(printf '%s\\n' "$user_section" | json_string loginType)
+                        last_login=$(printf '%s\\n' "$user_section" | json_string lastLoginDate)
+                        login_user_name=$(printf '%s\\n' "$user_section" | json_string loginUserName)
+
+                        # The real UPN lives in kerberosStatus, not in a userPrincipalName key
+                        # (no such key exists). Prefer the on-prem realm entry; the cloud entry
+                        # escapes the local part and appends the Kerberos realm, so unwrap it
+                        # as a fallback.
+                        upn=$(printf '%s\\n' "$user_section" | grep '"upn"' \\
+                            | grep -v 'KERBEROS.MICROSOFTONLINE.COM' | head -1 \\
+                            | sed 's/.*: *"\\(.*\\)".*/\\1/')
+                        if [ -z "$upn" ]; then
+                            upn=$(printf '%s\\n' "$user_section" | grep '"upn"' | head -1 \\
+                                | sed 's/.*: *"\\(.*\\)".*/\\1/' \\
+                                | sed 's/@KERBEROS\\.MICROSOFTONLINE\\.COM$//' \\
+                                | sed 's/\\\\@/@/g')
+                        fi
+
+                        # A populated User Configuration block is the only per-user proof of
+                        # registration.
+                        if [ -n "$unique_id" ] || [ -n "$login_user_name" ]; then
+                            registered="true"
+                        fi
+
+                        # SSO Tokens trailer is plain text, not JSON:
+                        #   SSO Tokens:
+                        #   Received:
+                        #   2026-08-14T00:18:46Z
+                        #   Expiration:
+                        #   2026-08-28T00:18:45Z (Not Expired)
+                        if printf '%s\\n' "$token_section" | grep -q '^Received:'; then
+                            token_received=$(printf '%s\\n' "$token_section" \\
+                                | awk '/^Received:/{getline; gsub(/^[ \\t]+|[ \\t]+$/,""); print; exit}')
+                            token_expiration_raw=$(printf '%s\\n' "$token_section" \\
+                                | awk '/^Expiration:/{getline; gsub(/^[ \\t]+|[ \\t]+$/,""); print; exit}')
+                            token_expiration=$(printf '%s' "$token_expiration_raw" | sed 's/ *(.*$//')
+                            case "$token_expiration_raw" in
+                                *"Not Expired"*) token_expired="false" ;;
+                                *"Expired"*)     token_expired="true" ;;
+                            esac
+                            if [ -n "$token_received" ]; then
+                                has_tokens="true"
+                            fi
+                        fi
                     fi
-                    
-                    # Try to extract user principal name
-                    user_upn=$(echo "$user_sso" | grep '"userPrincipalName"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
+                fi
+
+                if [ "$registered" = "true" ]; then
+                    registered_count=$((registered_count + 1))
                 else
                     unregistered_count=$((unregistered_count + 1))
                 fi
-                
-                if [ "$first_user" = "true" ]; then
-                    first_user="false"
-                else
-                    users_json="$users_json,"
+                if [ "$has_tokens" = "true" ]; then
+                    token_count=$((token_count + 1))
                 fi
-                
+
+                [ "$first_user" = "true" ] && first_user="false" || users_json="$users_json,"
                 users_json="$users_json{"
-                users_json="$users_json\\"username\\": \\"$user\\","
-                users_json="$users_json\\"registered\\": $user_registered,"
-                users_json="$users_json\\"userPrincipalName\\": \\"$user_upn\\""
+                users_json="$users_json\\"username\\": \\"$(json_scrub "$user")\\","
+                users_json="$users_json\\"uid\\": $uid,"
+                users_json="$users_json\\"registered\\": $registered,"
+                users_json="$users_json\\"userPrincipalName\\": \\"$(json_scrub "$upn")\\","
+                users_json="$users_json\\"loginUserName\\": \\"$(json_scrub "$login_user_name")\\","
+                users_json="$users_json\\"uniqueIdentifier\\": \\"$(json_scrub "$unique_id")\\","
+                users_json="$users_json\\"state\\": \\"$(json_scrub "$user_state")\\","
+                users_json="$users_json\\"loginType\\": \\"$(json_scrub "$login_type")\\","
+                users_json="$users_json\\"lastLoginDate\\": \\"$(json_scrub "$last_login")\\","
+                users_json="$users_json\\"tokensPresent\\": $has_tokens,"
+                users_json="$users_json\\"tokenReceived\\": \\"$(json_scrub "$token_received")\\","
+                users_json="$users_json\\"tokenExpiration\\": \\"$(json_scrub "$token_expiration")\\","
+                users_json="$users_json\\"tokenExpired\\": $token_expired,"
+                users_json="$users_json\\"probeStatus\\": \\"$probe_status\\""
                 users_json="$users_json}"
             done
-            
             users_json="$users_json]"
-            
+
             echo "{"
             echo "  \\"supported\\": true,"
-            echo "  \\"deviceRegistered\\": true,"
+            echo "  \\"deviceRegistered\\": $device_registered,"
+            echo "  \\"provider\\": \\"$(json_scrub "$provider")\\","
+            echo "  \\"method\\": \\"$(json_scrub "$method")\\","
+            echo "  \\"extensionIdentifier\\": \\"$(json_scrub "$extension_id")\\","
+            echo "  \\"organizationName\\": \\"$(json_scrub "$org_name")\\","
+            echo "  \\"loginFrequency\\": $login_freq,"
+            echo "  \\"offlineGracePeriod\\": \\"$(json_scrub "$offline_grace")\\","
             echo "  \\"registeredUserCount\\": $registered_count,"
             echo "  \\"unregisteredUserCount\\": $unregistered_count,"
+            echo "  \\"tokenPresentCount\\": $token_count,"
+            echo "  \\"nonPlatformSSOAccounts\\": $non_psso_json,"
             echo "  \\"users\\": $users_json"
             echo "}"
         """
-        
+
         return try await executeWithFallback(
             osquery: nil,
             bash: bashScript

--- a/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
@@ -3,17 +3,16 @@ import Foundation
 /// Identity module processor - collects user accounts, sessions, and identity management data
 /// Based on MunkiReport patterns for user/account collection
 /// Reference: https://github.com/munkireport/users, https://github.com/munkireport/user_sessions
-/// Collects: local users, group memberships, login sessions, Platform SSO user data,
-///           background task management database health (critical for shared Mac environments)
+/// Collects: local users, group memberships, login sessions, Platform SSO user data
 public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
-    
+
     public init(configuration: ReportMateConfiguration) {
         super.init(moduleId: "identity", configuration: configuration)
     }
-    
+
     public override func collectData() async throws -> ModuleData {
         // Total collection steps for progress tracking
-        let totalSteps = 8
+        let totalSteps = 7
         
         // Collect identity data sequentially with progress tracking
         ConsoleFormatter.writeQueryProgress(queryName: "user_accounts", current: 1, total: totalSteps)
@@ -28,32 +27,27 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         ConsoleFormatter.writeQueryProgress(queryName: "login_history", current: 4, total: totalSteps)
         let loginHistory = try await collectLoginHistory()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "btmdb_health", current: 5, total: totalSteps)
-        let btmdbHealth = try await collectBTMDBHealth()
-        
-        ConsoleFormatter.writeQueryProgress(queryName: "directory_services", current: 6, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "directory_services", current: 5, total: totalSteps)
         let directoryServices = try await collectDirectoryServices()
-        
-        ConsoleFormatter.writeQueryProgress(queryName: "secure_token_users", current: 7, total: totalSteps)
+
+        ConsoleFormatter.writeQueryProgress(queryName: "secure_token_users", current: 6, total: totalSteps)
         let secureTokenUsers = try await collectSecureTokenUsers()
-        
-        ConsoleFormatter.writeQueryProgress(queryName: "platform_sso_users", current: 8, total: totalSteps)
+
+        ConsoleFormatter.writeQueryProgress(queryName: "platform_sso_users", current: 7, total: totalSteps)
         let platformSSOUsers = try await collectPlatformSSOUsers()
-        
+
         // Build identity data dictionary
         let identityData: [String: Any] = [
             "users": userAccounts,
             "groups": groups,
             "loggedInUsers": loggedInUsers,
             "loginHistory": loginHistory,
-            "btmdbHealth": btmdbHealth,
             "directoryServices": directoryServices,
             "secureTokenUsers": secureTokenUsers,
             "platformSSOUsers": platformSSOUsers,
             "summary": buildSummary(
                 users: userAccounts,
-                loggedIn: loggedInUsers,
-                btmdb: btmdbHealth
+                loggedIn: loggedInUsers
             )
         ]
         
@@ -419,121 +413,6 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         }
         
         return []
-    }
-    
-    // MARK: - BTM Database Health (Critical for Shared Macs)
-    
-    /// Collects background task management database health metrics
-    /// Critical for shared Mac environments where BTMDB can exceed 4MB limit
-    /// causing loginwindow deadlocks and system freezes
-    private func collectBTMDBHealth() async throws -> [String: Any] {
-        let bashScript = """
-            # Background Task Management Database Health Check
-            # Critical for shared Mac environments (labs, classrooms)
-            # BTMDB can't exceed ~4MB as of macOS Tahoe - causes loginwindow deadlocks
-            
-            btmdb_path="/private/var/db/com.apple.backgroundtaskmanagement"
-            
-            # Get database size - the physical directory may be empty on modern macOS
-            # because the actual data is managed by the system. Use sfltool output
-            # size as a proxy for the effective database size.
-            db_size_bytes=0
-            db_size_mb="0.00"
-            db_exists=false
-            
-            if [ -d "$btmdb_path" ]; then
-                db_exists=true
-                
-                # First try file-based size (traditional approach)
-                raw_size=$(find "$btmdb_path" -type f -exec stat -f%z {} + 2>/dev/null | awk '{s+=$1} END {print s+0}')
-                file_size_bytes=$((${raw_size:-0} + 0))
-                
-                # If directory is empty, use sfltool dumpbtm output size as proxy
-                # This represents the actual data managed by the BTM service
-                if [ "$file_size_bytes" -eq 0 ]; then
-                    btm_dump_size=$(sfltool dumpbtm 2>/dev/null | wc -c | tr -d ' ')
-                    db_size_bytes=$((${btm_dump_size:-0} + 0))
-                else
-                    db_size_bytes=$file_size_bytes
-                fi
-                
-                # Calculate MB with awk for reliability (bc may not be available)
-                db_size_mb=$(awk "BEGIN {printf \\"%.2f\\", $db_size_bytes / 1048576}")
-            fi
-            
-            # Determine health status based on size thresholds
-            # Warning: 3MB, Critical: 3.5MB, Failure likely: 4MB+
-            status="healthy"
-            status_message="Database size within normal limits"
-            
-            if [ "$db_size_bytes" -gt 4194304 ] 2>/dev/null; then
-                status="critical"
-                status_message="Database exceeds 4MB - loginwindow deadlocks likely"
-            elif [ "$db_size_bytes" -gt 3670016 ] 2>/dev/null; then
-                status="critical"
-                status_message="Database exceeds 3.5MB - approaching failure threshold"
-            elif [ "$db_size_bytes" -gt 3145728 ] 2>/dev/null; then
-                status="warning"
-                status_message="Database exceeds 3MB - monitoring recommended"
-            fi
-            
-            # Count jetsam kills in last 7 days (backgroundtaskmanagementd memory limit exceeded)
-            jetsam_count=0
-            last_jetsam=""
-            
-            jetsam_output=$(log show --predicate 'eventMessage CONTAINS "backgroundtaskmanagementd" AND eventMessage CONTAINS "jetsam reason per-process-limit"' --style syslog --info --last 7d 2>/dev/null || echo "")
-            
-            if [ -n "$jetsam_output" ]; then
-                raw_jetsam_count=$(echo "$jetsam_output" | grep -c "jetsam reason per-process-limit" 2>/dev/null || echo "0")
-                # Ensure it's a valid integer
-                jetsam_count=$((raw_jetsam_count + 0))
-                last_jetsam=$(echo "$jetsam_output" | tail -1 | awk '{print $1, $2}' || echo "")
-            fi
-            
-            # If high jetsam count, escalate status
-            if [ "$jetsam_count" -gt 100 ] 2>/dev/null && [ "$status" = "healthy" ]; then
-                status="warning"
-                status_message="High backgroundtaskmanagementd jetsam kill rate ($jetsam_count in 7 days)"
-            elif [ "$jetsam_count" -gt 200 ] 2>/dev/null; then
-                status="critical"
-                status_message="Critical backgroundtaskmanagementd instability ($jetsam_count jetsam kills in 7 days)"
-            fi
-            
-            # Get number of registered background items
-            item_count=0
-            if [ -d "$btmdb_path" ]; then
-                raw_item_count=$(sfltool dumpbtm 2>/dev/null | grep -c "Name:" || echo "0")
-                item_count=$((raw_item_count + 0))
-            fi
-            
-            # Get number of local user accounts (correlates with BTM growth)
-            raw_user_count=$(dscl . -list /Users UniqueID 2>/dev/null | awk '$2 >= 500 && $2 < 65534' | wc -l | tr -d ' ')
-            user_count=$((raw_user_count + 0))
-            
-            # Output proper JSON with unquoted booleans and numbers
-            echo "{"
-            echo "  \\"exists\\": $db_exists,"
-            echo "  \\"path\\": \\"$btmdb_path\\","
-            echo "  \\"sizeBytes\\": $db_size_bytes,"
-            echo "  \\"sizeMB\\": $db_size_mb,"
-            echo "  \\"status\\": \\"$status\\","
-            echo "  \\"statusMessage\\": \\"$status_message\\","
-            echo "  \\"jetsamKillsLast7Days\\": $jetsam_count,"
-            echo "  \\"lastJetsamEvent\\": \\"$last_jetsam\\","
-            echo "  \\"registeredItemCount\\": $item_count,"
-            echo "  \\"localUserCount\\": $user_count,"
-            echo "  \\"thresholds\\": {"
-            echo "    \\"warningMB\\": 3.0,"
-            echo "    \\"criticalMB\\": 3.5,"
-            echo "    \\"failureMB\\": 4.0"
-            echo "  }"
-            echo "}"
-        """
-        
-        return try await executeWithFallback(
-            osquery: nil,
-            bash: bashScript
-        )
     }
     
     // MARK: - Directory Services
@@ -956,8 +835,7 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
     
     private func buildSummary(
         users: [[String: Any]],
-        loggedIn: [[String: Any]],
-        btmdb: [String: Any]
+        loggedIn: [[String: Any]]
     ) -> [String: Any] {
         let totalUsers = users.count
         let adminCount = users.filter { ($0["isAdmin"] as? Bool) == true || ($0["is_admin"] as? Bool) == true }.count
@@ -971,15 +849,12 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             return nil
         })
         let loggedInCount = uniqueLoggedInUsers.count
-        
-        let btmdbStatus = btmdb["status"] as? String ?? "unknown"
-        
+
         return [
             "totalUsers": totalUsers,
             "adminUsers": adminCount,
             "disabledUsers": disabledCount,
-            "currentlyLoggedIn": loggedInCount,
-            "btmdbStatus": btmdbStatus
+            "currentlyLoggedIn": loggedInCount
         ]
     }
 }

--- a/Sources/DataCollection/Modules/InstallsModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/InstallsModuleProcessor.swift
@@ -326,23 +326,19 @@ public class InstallsModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             fi
             """
         
-        // Execute bash script
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
-        process.arguments = ["-c", bashScript]
-        
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
-        
+        // Execute bash script through ProcessRunner. This reads a Munki log and truncates at
+        // 100KB below, so it deliberately expects output well past the 64KB pipe buffer — and
+        // the previous `waitUntilExit()` before reading deadlocked at exactly that point. The
+        // machines with the most log data were the ones that hung.
         do {
-            try process.run()
-            process.waitUntilExit()
-            
-            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-            if let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !output.isEmpty {
+            let result = try await ProcessRunner.bash(bashScript)
+            if result.timedOut {
+                ConsoleFormatter.writeDebug("Munki log read exceeded its time budget")
+                return ""
+            }
+
+            let output = result.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !output.isEmpty {
                 // Limit to reasonable size (100KB max to avoid bloating the payload)
                 let maxSize = 100_000
                 if output.count > maxSize {
@@ -408,16 +404,13 @@ public class InstallsModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         
         // Get Munki version from the binary
         if FileManager.default.fileExists(atPath: "/usr/local/munki/managedsoftwareupdate") {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/local/munki/managedsoftwareupdate")
-            process.arguments = ["--version"]
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = Pipe()
-            try? process.run()
-            process.waitUntilExit()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            if let version = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !version.isEmpty {
+            let result = try? await ProcessRunner.run(
+                executable: "/usr/local/munki/managedsoftwareupdate",
+                arguments: ["--version"],
+                timeout: 30
+            )
+            let version = (result?.standardOutput ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if result?.timedOut != true, !version.isEmpty {
                 info["version"] = version
             }
         }

--- a/Sources/DataCollection/Modules/ManagementModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/ManagementModuleProcessor.swift
@@ -778,22 +778,16 @@ public class ManagementModuleProcessor: BaseModuleProcessor, @unchecked Sendable
     
     /// Fallback method using profiles list command (basic info only)
     private func collectInstalledProfilesBasic() async throws -> [[String: Any]] {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/profiles")
-        process.arguments = ["list"]
-        
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
-        
-        try process.run()
-        process.waitUntilExit()
-        
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        guard let output = String(data: data, encoding: .utf8) else {
+        let result = try await ProcessRunner.run(
+            executable: "/usr/bin/profiles",
+            arguments: ["list"]
+        )
+        guard !result.timedOut else {
+            ConsoleFormatter.writeDebug("profiles list exceeded its time budget")
             return []
         }
-        
+        let output = result.standardOutput
+
         var profiles: [[String: Any]] = []
         var currentProfile: [String: Any]? = nil
         
@@ -945,19 +939,16 @@ public class ManagementModuleProcessor: BaseModuleProcessor, @unchecked Sendable
     
     // MARK: - Helper to execute bash commands
     
-    private func executeBashCommand(_ command: String) async throws -> String {
-        let process = Process()
-        let pipe = Pipe()
-        
-        process.standardOutput = pipe
-        process.standardError = pipe
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
-        process.arguments = ["-c", command]
-        
-        try process.run()
-        process.waitUntilExit()
-        
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8) ?? ""
+    /// Runs through ProcessRunner rather than driving Process directly. The previous version
+    /// called `waitUntilExit()` and only then read the pipe, which deadlocks once a command
+    /// produces more than a 64KB pipe buffer — a hang determined by output size rather than by
+    /// any misbehaving command, and this helper takes arbitrary commands.
+    private func executeBashCommand(_ command: String, timeout: TimeInterval = ProcessRunner.defaultTimeout) async throws -> String {
+        let result = try await ProcessRunner.bash(command, timeout: timeout)
+        if result.timedOut {
+            ConsoleFormatter.writeDebug("Management command exceeded its \(Int(timeout))s budget: \(command)")
+        }
+        // Preserves the previous behaviour of merging stderr into the returned text.
+        return result.standardOutput + result.standardError
     }
 }

--- a/Sources/DataCollection/Modules/ManagementModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/ManagementModuleProcessor.swift
@@ -308,76 +308,148 @@ public class ManagementModuleProcessor: BaseModuleProcessor, @unchecked Sendable
     }
     
     // MARK: - MDM Certificate Details (APNs Topic, SCEP, Identity Certificate)
-    
+    /// Resolves the MDM identity certificate from the enrollment profile itself.
+    ///
+    /// The `com.apple.mdm` payload names its own identity certificate by UUID. That UUID
+    /// resolves to the payload which provisions the certificate - ACME, SCEP or PKCS12 -
+    /// which in turn carries the certificate's subject CN. That chain is authoritative and
+    /// vendor-neutral.
+    ///
+    /// Matching keychain labels against an "MDM" substring is not. It picks up stale
+    /// certificates left behind by previous enrollments, and it cannot match an Intune
+    /// identity at all, because Intune names those by bare GUID. A device that had been
+    /// migrated off another MDM reported that MDM's dead certificate, its issuer, and an
+    /// expiry sixteen months later than the real one.
     private func collectMDMCertificateDetails() async throws -> [String: Any] {
         let bashScript = """
             push_topic=""
+            server_url=""
+            checkin_url=""
             scep_url=""
             cert_name=""
             cert_subject=""
             cert_issuer=""
             cert_expires=""
             mdm_provider=""
+            enrollment_method=""
+            identity_payload_type=""
+            enrollment_url=""
 
-            # Get Push Topic from system_profiler (not profiles command)
-            push_topic=$(system_profiler SPConfigurationProfileDataType 2>/dev/null | grep "Topic" | head -1 | sed 's/.*= "//' | sed 's/".*//' | tr -d ';')
+            # profiles(1) emits an XML plist carrying <data> blobs (certificates) and a
+            # <date>, neither of which plutil renders as JSON, so drop the blobs and retype
+            # the dates before converting.
+            profiles_json=$(/usr/bin/profiles show -type configuration -o stdout-xml 2>/dev/null \\
+                | awk '
+                    /<data>/ { print "<string>[data]</string>"; if ($0 ~ /<\\/data>/) next; ind=1; next }
+                    ind && /<\\/data>/ { ind=0; next }
+                    ind { next }
+                    { print }
+                  ' \\
+                | sed 's|<date>|<string>|g; s|</date>|</string>|g' \\
+                | plutil -convert json -o - - 2>/dev/null)
 
-            # Get SCEP URL by deriving from MDM ServerURL (filter for /mdm/ to avoid Crypt etc)
-            mdm_server=$(system_profiler SPConfigurationProfileDataType 2>/dev/null | grep "ServerURL" | grep "/mdm/" | head -1 | sed 's/.*= "//' | sed 's/".*//' | tr -d ';')
-            if [ -n "$mdm_server" ]; then
-                base_url=$(echo "$mdm_server" | sed 's|/mdm/.*||')
-                scep_url="${base_url}/scep"
-            fi
+            if [ -n "$profiles_json" ]; then
+                mdm_facts=$(printf '%s' "$profiles_json" | jq -r '
+                    [ ._computerlevel[]? | .ProfileItems[]? | select(.PayloadType == "com.apple.mdm") ] as $mdm
+                    | ($mdm[0].PayloadContent // {}) as $c
+                    | [ ._computerlevel[]? | .ProfileItems[]?
+                        | select(.PayloadUUID != null and .PayloadUUID == $c.IdentityCertificateUUID) ] as $id
+                    | ($id[0] // {}) as $idp
+                    | [ ($c.ServerURL // ""),
+                        ($c.CheckInURL // ""),
+                        ($c.Topic // ""),
+                        ($idp.PayloadType // ""),
+                        (($idp.PayloadContent.Subject // []) | flatten | if length >= 2 then .[1] else "" end),
+                        ($idp.PayloadContent.URL // $idp.PayloadContent.DirectoryURL // "")
+                      ] | @tsv' 2>/dev/null)
 
-            # Get MDM certificate - use MOST RECENT certificate (sort by expiration date)
-            # This handles cases where device has multiple MDM certs (re-enrollment, device+user certs)
-            # Convert dates to epoch for proper numerical sorting
-            cert_name=$(security find-certificate -a /Library/Keychains/System.keychain 2>/dev/null | \
-                grep '"labl"' | grep -iE "MDM|Identity" | \
-                while read line; do
-                    name=$(echo "$line" | sed 's/.*="\\(.*\\)".*/\\1/')
-                    expiry_str=$(security find-certificate -c "$name" -p /Library/Keychains/System.keychain 2>/dev/null | \
-                        openssl x509 -noout -enddate 2>/dev/null | sed 's/notAfter=//')
-                    # Convert to epoch time for proper numerical sorting (latest expiry = highest number)
-                    expiry_epoch=$(date -jf "%b %d %T %Y %Z" "$expiry_str" "+%s" 2>/dev/null || echo "0")
-                    echo "$expiry_epoch|||$name"
-                done | sort -rn | head -1 | cut -d'|' -f4-)
-            
-            if [ -n "$cert_name" ]; then
-                cert_subject="$cert_name"
-                
-                # Get issuer and expiry from the certificate
-                cert_info=$(security find-certificate -c "$cert_name" -p /Library/Keychains/System.keychain 2>/dev/null | openssl x509 -noout -subject -issuer -enddate 2>/dev/null)
-                if [ -n "$cert_info" ]; then
-                    cert_issuer=$(echo "$cert_info" | grep "^issuer=" | sed 's/issuer=//' | sed 's/.*CN=//' | sed 's/,.*//')
-                    cert_expires=$(echo "$cert_info" | grep "^notAfter=" | sed 's/notAfter=//')
+                if [ -n "$mdm_facts" ]; then
+                    server_url=$(printf '%s' "$mdm_facts" | cut -f1)
+                    checkin_url=$(printf '%s' "$mdm_facts" | cut -f2)
+                    push_topic=$(printf '%s' "$mdm_facts" | cut -f3)
+                    identity_payload_type=$(printf '%s' "$mdm_facts" | cut -f4)
+                    cert_subject=$(printf '%s' "$mdm_facts" | cut -f5)
+                    enrollment_url=$(printf '%s' "$mdm_facts" | cut -f6)
                 fi
             fi
 
-            # Determine MDM provider from issuer or cert name
-            check_str=$(echo "$cert_issuer $cert_name" | tr '[:upper:]' '[:lower:]')
-            case "$check_str" in
-                *micromdm*) mdm_provider="MicroMDM" ;;
-                *nanomdm*) mdm_provider="NanoMDM" ;;
-                *jamf*) mdm_provider="Jamf Pro" ;;
-                *mosyle*) mdm_provider="Mosyle" ;;
-                *kandji*) mdm_provider="Kandji" ;;
-                *intune*|*microsoft*) mdm_provider="Microsoft Intune" ;;
-                *workspace*|*airwatch*) mdm_provider="VMware Workspace ONE" ;;
-                *) [ -n "$cert_issuer" ] && mdm_provider="$cert_issuer" ;;
+            # How the identity certificate is provisioned. Intune issues over ACME on
+            # current macOS, so a SCEP yes/no answers the wrong question.
+            case "$identity_payload_type" in
+                com.apple.security.acme)   enrollment_method="ACME" ;;
+                com.apple.security.scep)   enrollment_method="SCEP" ;;
+                com.apple.security.pkcs12) enrollment_method="PKCS12" ;;
+                "")                        enrollment_method="" ;;
+                *)                         enrollment_method="$identity_payload_type" ;;
             esac
 
+            # The enrollment URL carries session metadata in its query string; keep the
+            # endpoint for diagnostics without recording the rest.
+            if [ -n "$enrollment_url" ]; then
+                scep_url=$(printf '%s' "$enrollment_url" | sed 's/?.*//')
+            fi
+
+            # Resolve the certificate by the exact CN the profile named. Renewals can leave
+            # several certificates sharing a CN, so take the one that expires last.
+            if [ -n "$cert_subject" ]; then
+                cert_name="$cert_subject"
+                newest_epoch=0
+                tmp_pem=$(mktemp /tmp/reportmate-mdmcert.XXXXXX)
+                security find-certificate -a -c "$cert_subject" -p /Library/Keychains/System.keychain 2>/dev/null > "$tmp_pem"
+
+                if [ -s "$tmp_pem" ]; then
+                    awk 'BEGIN{n=0} /-----BEGIN CERTIFICATE-----/{n++} {print > ("'"$tmp_pem"'." n)}' "$tmp_pem"
+                    for part in "$tmp_pem".*; do
+                        [ -e "$part" ] || continue
+                        info=$(openssl x509 -noout -subject -issuer -enddate -in "$part" 2>/dev/null)
+                        [ -n "$info" ] || continue
+                        this_cn=$(printf '%s' "$info" | grep '^subject=' | sed 's/.*CN *= *//' | sed 's/,.*//')
+                        [ "$this_cn" = "$cert_subject" ] || continue
+                        this_exp=$(printf '%s' "$info" | grep '^notAfter=' | sed 's/notAfter=//')
+                        this_epoch=$(date -jf "%b %d %T %Y %Z" "$this_exp" "+%s" 2>/dev/null || echo 0)
+                        if [ "$this_epoch" -ge "$newest_epoch" ]; then
+                            newest_epoch=$this_epoch
+                            cert_expires="$this_exp"
+                            cert_issuer=$(printf '%s' "$info" | grep '^issuer=' | sed 's/.*CN *= *//' | sed 's/,.*//')
+                        fi
+                    done
+                    rm -f "$tmp_pem".*
+                fi
+                rm -f "$tmp_pem"
+            fi
+
+            # Identify the vendor from the enrollment endpoint - what the device actually
+            # talks to - falling back to the issuing CA.
+            check_str=$(printf '%s %s' "$server_url" "$cert_issuer" | tr '[:upper:]' '[:lower:]')
+            case "$check_str" in
+                *manage.microsoft.com*|*intune*)   mdm_provider="Microsoft Intune" ;;
+                *jamfcloud*|*jamf*)                mdm_provider="Jamf Pro" ;;
+                *micromdm*)                        mdm_provider="MicroMDM" ;;
+                *nanomdm*)                         mdm_provider="NanoMDM" ;;
+                *mosyle*)                          mdm_provider="Mosyle" ;;
+                *kandji*)                          mdm_provider="Kandji" ;;
+                *awmdm*|*airwatch*|*workspaceone*) mdm_provider="VMware Workspace ONE" ;;
+                *addigy*)                          mdm_provider="Addigy" ;;
+                *)                                 mdm_provider="$cert_issuer" ;;
+            esac
+
+            json_escape() { printf '%s' "$1" | sed -e 's/\\\\/\\\\\\\\/g' -e 's/"/\\\\"/g'; }
+
             echo "{"
-            echo "  \\"push_topic\\": \\"$push_topic\\","
-            echo "  \\"scep_url\\": \\"$scep_url\\","
-            echo "  \\"certificate_name\\": \\"$cert_name\\","
-            echo "  \\"certificate_subject\\": \\"$cert_subject\\","
-            echo "  \\"certificate_issuer\\": \\"$cert_issuer\\","
-            echo "  \\"certificate_expires\\": \\"$cert_expires\\","
-            echo "  \\"mdm_provider\\": \\"$mdm_provider\\""
+            echo "  \\"push_topic\\": \\"$(json_escape "$push_topic")\\","
+            echo "  \\"server_url\\": \\"$(json_escape "$server_url")\\","
+            echo "  \\"checkin_url\\": \\"$(json_escape "$checkin_url")\\","
+            echo "  \\"scep_url\\": \\"$(json_escape "$scep_url")\\","
+            echo "  \\"certificate_name\\": \\"$(json_escape "$cert_name")\\","
+            echo "  \\"certificate_subject\\": \\"$(json_escape "$cert_subject")\\","
+            echo "  \\"certificate_issuer\\": \\"$(json_escape "$cert_issuer")\\","
+            echo "  \\"certificate_expires\\": \\"$(json_escape "$cert_expires")\\","
+            echo "  \\"certificate_enrollment_method\\": \\"$(json_escape "$enrollment_method")\\","
+            echo "  \\"identity_payload_type\\": \\"$(json_escape "$identity_payload_type")\\","
+            echo "  \\"mdm_provider\\": \\"$(json_escape "$mdm_provider")\\""
             echo "}"
         """
-        
+
         return try await executeWithFallback(
             osquery: nil,
             bash: bashScript

--- a/Sources/DataCollection/Modules/SecurityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/SecurityModuleProcessor.swift
@@ -14,7 +14,7 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
     
     public override func collectData() async throws -> ModuleData {
         // Total collection steps for progress tracking
-        let totalSteps = 23
+        let totalSteps = 22
         
         // Collect security data sequentially with progress tracking
         ConsoleFormatter.writeQueryProgress(queryName: "sip_status", current: 1, total: totalSteps)
@@ -53,37 +53,37 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         ConsoleFormatter.writeQueryProgress(queryName: "activation_lock", current: 12, total: totalSteps)
         let activationLock = try await collectActivationLockStatus()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "platform_sso", current: 13, total: totalSteps)
-        let platformSSO = try await collectPlatformSSOStatus()
-        
-        ConsoleFormatter.writeQueryProgress(queryName: "filevault_users", current: 14, total: totalSteps)
+        // Platform SSO is an identity concern, not a security-posture one, and lives in the
+        // identity module (identity.platformSSO). It was collected here as well, which meant
+        // it also sat behind this module's slower probes.
+        ConsoleFormatter.writeQueryProgress(queryName: "filevault_users", current: 13, total: totalSteps)
         let fvUsers = try await collectFileVaultUsers()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "secure_token", current: 15, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "secure_token", current: 14, total: totalSteps)
         let secureToken = try await collectSecureTokenStatus()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "bootstrap_token", current: 16, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "bootstrap_token", current: 15, total: totalSteps)
         let bootstrapToken = try await collectBootstrapTokenStatus()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "authdb", current: 17, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "authdb", current: 16, total: totalSteps)
         let authdb = try await collectAuthDB()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "unpatched_cves", current: 18, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "unpatched_cves", current: 17, total: totalSteps)
         let unpatchedCVEs = try await collectSofaUnpatchedCVEs()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "security_release", current: 19, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "security_release", current: 18, total: totalSteps)
         let securityRelease = try await collectSofaSecurityReleaseInfo()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "remote_management", current: 20, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "remote_management", current: 19, total: totalSteps)
         let remoteMgmt = try await collectRemoteManagement()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "certificates", current: 21, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "certificates", current: 20, total: totalSteps)
         let certificates = try await collectCertificates()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "endpoint_security", current: 22, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "endpoint_security", current: 21, total: totalSteps)
         let endpointSecurity = try await collectEndpointSecurityExtensions()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "edr_products", current: 23, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "edr_products", current: 22, total: totalSteps)
         let edrProducts = try await collectEDRProducts()
         
         // Build security data dictionary
@@ -103,7 +103,6 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             "mrt": mrt,
             "secureEnclave": secureEnclave,
             "activationLock": activationLock,
-            "platformSSO": platformSSO,
             "authorizationDB": authdb,
             "unpatchedCVEs": unpatchedCVEs,
             "securityReleaseInfo": securityRelease,
@@ -1136,248 +1135,6 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         )
     }
     
-    // MARK: - Platform Single Sign-On Status (bash: app-sso)
-    
-    private func collectPlatformSSOStatus() async throws -> [String: Any] {
-        // Platform SSO is macOS 13+ feature for enterprise single sign-on
-        // Uses the app-sso command-line tool with -s flag to get state (JSON-like format)
-        // Collects comprehensive device config + per-user SSO data
-        let bashScript = """
-            # Platform SSO status check (macOS 13+ Ventura and later)
-            # Collects device-level config and per-user SSO registration
-            
-            # Check macOS version (Platform SSO requires 13+)
-            os_version=$(sw_vers -productVersion | cut -d. -f1)
-            if [ "$os_version" -lt 13 ]; then
-                echo "{"
-                echo "  \\"supported\\": false,"
-                echo "  \\"registered\\": false,"
-                echo "  \\"provider\\": \\"\\"," 
-                echo "  \\"method\\": \\"Not supported (macOS 13+ required)\\","
-                echo "  \\"extensionIdentifier\\": \\"\\"," 
-                echo "  \\"loginFrequency\\": 0,"
-                echo "  \\"offlineGracePeriod\\": \\"\\"," 
-                echo "  \\"users\\": []"
-                echo "}"
-                exit 0
-            fi
-            
-            # First get device-level SSO state (can run as root)
-            sso_state=$(app-sso platform -s 2>/dev/null || echo "")
-            
-            # Initialize device-level variables
-            registered="false"
-            sso_provider=""
-            method="Unknown"
-            extension_id=""
-            org_name=""
-            login_freq="0"
-            offline_grace=""
-            non_psso_accounts=""
-            
-            if [ -n "$sso_state" ]; then
-                # Check registration status
-                if echo "$sso_state" | grep -q '"registrationCompleted" *: *true'; then
-                    registered="true"
-                fi
-                
-                # Extract SSO extension identifier
-                extension_id=$(echo "$sso_state" | grep '"extensionIdentifier"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                
-                # Extract organization/account display name (first one is org name)
-                org_name=$(echo "$sso_state" | grep '"accountDisplayName"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                
-                # Extract provider from accountDisplayName (find the IdP entry)
-                provider_val=$(echo "$sso_state" | grep '"accountDisplayName"' | grep -i "Entra\\|Okta\\|Google\\|Jamf\\|Microsoft" | head -1 || echo "")
-                if echo "$provider_val" | grep -qi "Microsoft\\|Entra"; then
-                    sso_provider="Microsoft Entra ID"
-                elif echo "$provider_val" | grep -qi "Okta"; then
-                    sso_provider="Okta"
-                elif echo "$provider_val" | grep -qi "Google"; then
-                    sso_provider="Google"
-                elif echo "$provider_val" | grep -qi "Jamf"; then
-                    sso_provider="Jamf Connect"
-                fi
-                
-                # Extract login type / method
-                login_type=$(echo "$sso_state" | grep '"loginType"' | head -1 || echo "")
-                if echo "$login_type" | grep -qi "SecureEnclaveKey"; then
-                    method="Secure enclave key"
-                elif echo "$login_type" | grep -qi "Password"; then
-                    method="Password"
-                elif echo "$login_type" | grep -qi "SmartCard"; then
-                    method="Smart Card"
-                fi
-                
-                # Extract login frequency (seconds)
-                login_freq=$(echo "$sso_state" | grep '"loginFrequency"' | head -1 | sed 's/[^0-9]//g' || echo "0")
-                
-                # Extract offline grace period
-                offline_grace=$(echo "$sso_state" | grep '"offlineGracePeriod"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                
-                # Extract non-Platform SSO accounts (local accounts) - array format
-                non_psso_accounts=$(echo "$sso_state" | sed -n '/"nonPlatformSSOAccounts"/,/\\]/p' | grep -v 'nonPlatformSSOAccounts' | grep '"' | sed 's/.*"\\([^"]*\\)".*/\\1/' | tr '\\n' ',' | sed 's/,$//' || echo "")
-            fi
-            
-            # Now collect per-user SSO data (only if registered)
-            users_json="[]"
-            if [ "$registered" = "true" ]; then
-                # Get all human users on the system
-                all_users=$(dscl . -list /Users | grep -v "^_" | grep -v "daemon\\|nobody\\|root\\|Guest" || echo "")
-                
-                users_json="["
-                first_user="true"
-                
-                for user in $all_users; do
-                    # Get user's home directory to check if real user
-                    user_home=$(dscl . -read /Users/"$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}' || echo "")
-                    if [ ! -d "$user_home" ] || [ "$user_home" = "/var/empty" ]; then
-                        continue
-                    fi
-                    
-                    # Get SSO state for this user
-                    user_sso=$(sudo -u "$user" app-sso platform -s 2>/dev/null || echo "")
-                    
-                    user_registered="false"
-                    user_upn=""
-                    user_email=""
-                    user_tokens="false"
-                    user_last_login=""
-                    user_state=""
-                    token_received=""
-                    token_expiration=""
-                    
-                    if [ -n "$user_sso" ]; then
-                        # Check User Configuration section for this user's SSO data
-                        if echo "$user_sso" | grep -q "User Configuration:"; then
-                            # Extract UPN (prefer clean one without KERBEROS suffix)
-                            user_upn=$(echo "$user_sso" | grep '"upn"' | grep -v "KERBEROS" | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                            if [ -z "$user_upn" ]; then
-                                user_upn=$(echo "$user_sso" | grep '"upn"' | head -1 | sed 's/.*: *"\\([^@]*@[^@]*\\)@.*/\\1/' | sed 's/\\\\\\\\@/@/' || echo "")
-                            fi
-                            
-                            # Extract loginUserName (may be masked)
-                            user_email=$(echo "$user_sso" | grep '"loginUserName"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                            
-                            # Prefer UPN if email is masked
-                            if [ -n "$user_upn" ]; then
-                                if [ -z "$user_email" ] || echo "$user_email" | grep -q '\\*\\*\\*'; then
-                                    user_email="$user_upn"
-                                fi
-                            fi
-                            
-                            # If we have UPN or email, user is registered
-                            if [ -n "$user_upn" ] || [ -n "$user_email" ]; then
-                                user_registered="true"
-                            fi
-                            
-                            # Extract last login date
-                            user_last_login=$(echo "$user_sso" | grep '"lastLoginDate"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                            
-                            # Extract user state
-                            user_state=$(echo "$user_sso" | grep '"state"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                        fi
-                        
-                        # Check for SSO Tokens section (appears at end of output, not in JSON format)
-                        # Format is:
-                        # SSO Tokens:
-                        # Received:
-                        # 2026-01-16T17:48:17Z
-                        # Expiration:
-                        # 2026-01-30T17:48:16Z (Not Expired)
-                        if echo "$user_sso" | grep -q "^SSO Tokens:"; then
-                            # Extract the token received timestamp (line after "Received:")
-                            token_received=$(echo "$user_sso" | awk '/^Received:/{getline; print; exit}' | tr -d ' ')
-                            # Extract the token expiration (line after "Expiration:")
-                            token_expiration=$(echo "$user_sso" | awk '/^Expiration:/{getline; print; exit}' | sed 's/ *(.*$//' | tr -d ' ')
-                            
-                            # If we have a received timestamp, tokens are present
-                            if [ -n "$token_received" ] && [ "$token_received" != "" ]; then
-                                user_tokens="true"
-                            fi
-                        fi
-                    fi
-                    
-                    # Add user to JSON array if they have any SSO data
-                    if [ "$user_registered" = "true" ] || [ -n "$user_upn" ] || [ -n "$user_email" ]; then
-                        if [ "$first_user" = "true" ]; then
-                            first_user="false"
-                        else
-                            users_json="$users_json,"
-                        fi
-                        
-                        # Convert boolean to integer for tokensPresent (1 or 0)
-                        if [ "$user_tokens" = "true" ]; then
-                            tokens_val=1
-                        else
-                            tokens_val=0
-                        fi
-                        
-                        # Convert registered boolean to integer
-                        if [ "$user_registered" = "true" ]; then
-                            registered_val=1
-                        else
-                            registered_val=0
-                        fi
-                        
-                        users_json="$users_json{"
-                        users_json="$users_json\\"username\\": \\"$user\\","
-                        users_json="$users_json\\"registered\\": $registered_val,"
-                        users_json="$users_json\\"upn\\": \\"$user_upn\\","
-                        users_json="$users_json\\"loginEmail\\": \\"$user_email\\","
-                        users_json="$users_json\\"lastLogin\\": \\"$user_last_login\\","
-                        users_json="$users_json\\"state\\": \\"$user_state\\","
-                        users_json="$users_json\\"tokensPresent\\": $tokens_val,"
-                        users_json="$users_json\\"tokenReceived\\": \\"$token_received\\","
-                        users_json="$users_json\\"tokenExpiration\\": \\"$token_expiration\\""
-                        users_json="$users_json}"
-                    fi
-                done
-                users_json="$users_json]"
-            fi
-            
-            # Fallback: Check for SSO provider via profile if not found
-            if [ "$sso_provider" = "" ] && [ "$registered" = "false" ]; then
-                azure_check=$(profiles show -type configuration 2>/dev/null | grep -i "microsoft\\|azure\\|entra" || echo "")
-                okta_check=$(profiles show -type configuration 2>/dev/null | grep -i "okta" || echo "")
-                jamf_check=$(profiles show -type configuration 2>/dev/null | grep -i "jamf connect" || echo "")
-                
-                if [ -n "$azure_check" ]; then
-                    sso_provider="Microsoft Entra ID"
-                elif [ -n "$okta_check" ]; then
-                    sso_provider="Okta"
-                elif [ -n "$jamf_check" ]; then
-                    sso_provider="Jamf Connect"
-                fi
-            fi
-            
-            # Convert device-level registered to integer
-            if [ "$registered" = "true" ]; then
-                registered_int=1
-            else
-                registered_int=0
-            fi
-            
-            echo "{"
-            echo "  \\"supported\\": 1,"
-            echo "  \\"registered\\": $registered_int,"
-            echo "  \\"provider\\": \\"$sso_provider\\","
-            echo "  \\"method\\": \\"$method\\","
-            echo "  \\"extensionIdentifier\\": \\"$extension_id\\","
-            echo "  \\"organizationName\\": \\"$org_name\\","
-            echo "  \\"loginFrequency\\": $login_freq,"
-            echo "  \\"offlineGracePeriod\\": \\"$offline_grace\\","
-            echo "  \\"nonPlatformSSOAccounts\\": \\"$non_psso_accounts\\","
-            echo "  \\"users\\": $users_json"
-            echo "}"
-        """
-        
-        return try await executeWithFallback(
-            osquery: nil,
-            bash: bashScript
-        )
-    }
-    
     // MARK: - Authorization Database (extension: authdb)
     
     private func collectAuthDB() async throws -> [[String: Any]] {
@@ -1907,9 +1664,32 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         ConsoleFormatter.writeDebug("Microsoft Defender: mdatp CLI found, collecting health data")
         
         do {
-            // Get health status
-            let healthOutput = try await executeBashScript("/usr/local/bin/mdatp health --output json 2>/dev/null || echo '{}'")
-            
+            // Get health status. `mdatp health` can block indefinitely when the Defender
+            // daemon is wedged, which would stall the entire security collection - and with
+            // it the Platform SSO data reported below - so bound it and fall back to empty.
+            let healthOutput = try await executeBashScript("""
+                set -m
+                out=$(mktemp /tmp/reportmate-mdatp.XXXXXX) || { echo '{}'; exit 0; }
+                /usr/local/bin/mdatp health --output json >"$out" 2>/dev/null &
+                pid=$!
+                waited=0
+                while kill -0 "$pid" 2>/dev/null; do
+                    if [ "$waited" -ge 30 ]; then
+                        kill -9 -"$pid" 2>/dev/null
+                        kill -9 "$pid" 2>/dev/null
+                        wait "$pid" 2>/dev/null
+                        rm -f "$out"
+                        echo '{}'
+                        exit 0
+                    fi
+                    sleep 1
+                    waited=$((waited + 1))
+                done
+                wait "$pid" 2>/dev/null
+                if [ -s "$out" ]; then cat "$out"; else echo '{}'; fi
+                rm -f "$out"
+                """)
+
             guard let healthData = healthOutput.data(using: .utf8),
                   let healthJson = try? JSONSerialization.jsonObject(with: healthData) as? [String: Any] else {
                 ConsoleFormatter.writeDebug("Microsoft Defender: failed to parse health JSON")

--- a/Sources/DataCollection/Modules/SecurityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/SecurityModuleProcessor.swift
@@ -1635,21 +1635,21 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         ]
     }
     
-    /// Simple bash command execution helper for EDR collection
-    private func executeBashScript(_ script: String) async throws -> String {
-        let process = Process()
-        let pipe = Pipe()
-        
-        process.standardOutput = pipe
-        process.standardError = pipe
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
-        process.arguments = ["-c", script]
-        
-        try process.run()
-        process.waitUntilExit()
-        
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8) ?? ""
+    /// Simple bash command execution helper for EDR collection.
+    ///
+    /// Runs through ProcessRunner rather than driving Process directly. The previous version
+    /// called `waitUntilExit()` and only then read the pipe, which deadlocks outright once a
+    /// command produces more than a 64KB pipe buffer: the child blocks writing, the parent
+    /// waits for an exit that can never come. That is a hang determined by output size, not by
+    /// any misbehaving command, and this helper takes arbitrary commands.
+    private func executeBashScript(_ script: String, timeout: TimeInterval = ProcessRunner.defaultTimeout) async throws -> String {
+        let result = try await ProcessRunner.bash(script, timeout: timeout)
+        if result.timedOut {
+            ConsoleFormatter.writeDebug("EDR command exceeded its \(Int(timeout))s budget: \(script)")
+        }
+        // Preserves the previous behaviour of merging stderr into the returned text, which
+        // callers of this helper expect.
+        return result.standardOutput + result.standardError
     }
     
     /// Collect Microsoft Defender for Endpoint status via mdatp CLI

--- a/Sources/DataCollection/Services/ApplicationUsageService.swift
+++ b/Sources/DataCollection/Services/ApplicationUsageService.swift
@@ -392,6 +392,57 @@ public class ApplicationUsageService: @unchecked Sendable {
         return nil
     }
 
+    /// Running totals for one (date, app name) pair while summaries are built.
+    private struct DailyUsageBucket {
+        var launches = 0
+        var totalSeconds = 0.0
+        var foregroundSeconds = 0.0
+        var activeSeconds = 0.0
+        var users: Set<String> = []
+    }
+
+    /// The calendar days a session covers, each with the fraction of the
+    /// session's wall-clock span that fell on that day.
+    ///
+    /// A session is one continuous run of an application, so an app opened
+    /// before midnight and closed after it was in use on both days. Attributing
+    /// the whole run to the day it started — as this did previously — books a
+    /// week of uptime onto a single date and leaves the days it actually
+    /// covered empty, which makes any per-day or per-week series wrong.
+    ///
+    /// The foreground and active counters are accumulated across the whole
+    /// session rather than per day, so they are apportioned by the same
+    /// wall-clock share. That is an estimate; only per-day counters in the
+    /// watcher itself could make it exact.
+    private func daySpans(of session: ApplicationUsageSession,
+                          formatter: DateFormatter) -> [(String, Double)] {
+        let start = session.startTime
+        guard let end = session.endTime, end > start else {
+            return [(formatter.string(from: start), 1.0)]
+        }
+
+        let span = end.timeIntervalSince(start)
+        let calendar = Calendar.current
+        var spans: [(String, Double)] = []
+        var cursor = start
+
+        // Bounded by the watcher's 30-day retention; the cap only guards against
+        // a corrupt end_time far in the future turning this into a long loop.
+        while cursor < end, spans.count < 400 {
+            let dayStart = calendar.startOfDay(for: cursor)
+            guard let nextDay = calendar.date(byAdding: .day, value: 1, to: dayStart),
+                  nextDay > cursor else { break }
+            let segmentEnd = min(nextDay, end)
+            let seconds = segmentEnd.timeIntervalSince(cursor)
+            if seconds > 0 {
+                spans.append((formatter.string(from: cursor), seconds / span))
+            }
+            cursor = segmentEnd
+        }
+
+        return spans.isEmpty ? [(formatter.string(from: start), 1.0)] : spans
+    }
+
     /// Build daily per-application usage summaries from sessions.
     /// Groups by (date, app name). Cumulative: last collection of the day wins (UPSERT on API).
     public func buildDailySummaries(sessions: [ApplicationUsageSession]) -> [[String: Any]] {
@@ -409,37 +460,54 @@ public class ApplicationUsageService: @unchecked Sendable {
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.timeZone = TimeZone.current
 
-        // Group by (date string, app name)
-        var groups: [String: [ApplicationUsageSession]] = [:]
+        // Accumulate by (date string, app name). A session that runs past
+        // midnight belongs to every day it covers, not only the one it started
+        // on, so each session is split across the days it spans first.
+        var buckets: [String: DailyUsageBucket] = [:]
         for session in sessions {
-            let dateStr = dateFormatter.string(from: session.startTime)
-            let key = "\(dateStr)||\(session.name)"
-            groups[key, default: []].append(session)
-        }
-
-        var summaries: [[String: Any]] = []
-        for (key, grouped) in groups {
-            let parts = key.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
-            guard parts.count >= 3 else { continue }
-            let dateStr = String(parts[0])
-            let appName = String(parts[2])
-
-            let users = Array(Set(grouped.map { $0.user }.filter { !$0.isEmpty }))
-
             // A session interrupted by a watcher restart is stamped with the -1
             // unknown-duration sentinel (AppUsageDatabase.markOrphanedSessions).
             // It carries no measurable duration, so it contributes nothing here —
             // summing it raw would send a negative total to the server, which
             // reads these as real seconds and accumulates them.
+            let total = max(0, session.durationSeconds)
+            let foreground = max(0, session.foregroundSeconds)
+            let active = max(0, session.activeSeconds)
+            let startDate = dateFormatter.string(from: session.startTime)
+
+            for (dateStr, share) in daySpans(of: session, formatter: dateFormatter) {
+                let key = "\(dateStr)||\(session.name)"
+                var bucket = buckets[key] ?? DailyUsageBucket()
+                bucket.totalSeconds += total * share
+                bucket.foregroundSeconds += foreground * share
+                bucket.activeSeconds += active * share
+                if !session.user.isEmpty {
+                    bucket.users.insert(session.user)
+                }
+                // One app-open is one launch, counted on the day it happened —
+                // apportioning it too would multiply launch counts by the number
+                // of days a long-running app happened to stay open.
+                if dateStr == startDate {
+                    bucket.launches += 1
+                }
+                buckets[key] = bucket
+            }
+        }
+
+        var summaries: [[String: Any]] = []
+        for (key, bucket) in buckets {
+            let parts = key.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
+            guard parts.count >= 3 else { continue }
+
             summaries.append([
-                "date": dateStr,
-                "appName": appName,
+                "date": String(parts[0]),
+                "appName": String(parts[2]),
                 "publisher": "",
-                "launches": grouped.count,
-                "totalSeconds": grouped.reduce(0.0) { $0 + max(0, $1.durationSeconds) },
-                "foregroundSeconds": grouped.reduce(0.0) { $0 + max(0, $1.foregroundSeconds) },
-                "activeSeconds": grouped.reduce(0.0) { $0 + max(0, $1.activeSeconds) },
-                "users": users
+                "launches": bucket.launches,
+                "totalSeconds": bucket.totalSeconds,
+                "foregroundSeconds": bucket.foregroundSeconds,
+                "activeSeconds": bucket.activeSeconds,
+                "users": Array(bucket.users)
             ])
         }
 

--- a/Sources/DataCollection/Services/ApplicationUsageService.swift
+++ b/Sources/DataCollection/Services/ApplicationUsageService.swift
@@ -426,14 +426,19 @@ public class ApplicationUsageService: @unchecked Sendable {
 
             let users = Array(Set(grouped.map { $0.user }.filter { !$0.isEmpty }))
 
+            // A session interrupted by a watcher restart is stamped with the -1
+            // unknown-duration sentinel (AppUsageDatabase.markOrphanedSessions).
+            // It carries no measurable duration, so it contributes nothing here —
+            // summing it raw would send a negative total to the server, which
+            // reads these as real seconds and accumulates them.
             summaries.append([
                 "date": dateStr,
                 "appName": appName,
                 "publisher": "",
                 "launches": grouped.count,
-                "totalSeconds": grouped.reduce(0.0) { $0 + $1.durationSeconds },
-                "foregroundSeconds": grouped.reduce(0.0) { $0 + $1.foregroundSeconds },
-                "activeSeconds": grouped.reduce(0.0) { $0 + $1.activeSeconds },
+                "totalSeconds": grouped.reduce(0.0) { $0 + max(0, $1.durationSeconds) },
+                "foregroundSeconds": grouped.reduce(0.0) { $0 + max(0, $1.foregroundSeconds) },
+                "activeSeconds": grouped.reduce(0.0) { $0 + max(0, $1.activeSeconds) },
                 "users": users
             ])
         }

--- a/Sources/Models/Modules/IdentityModels.swift
+++ b/Sources/Models/Modules/IdentityModels.swift
@@ -335,39 +335,86 @@ public struct PlatformSSOUsersInfo: Codable, Sendable {
     public let deviceRegistered: Bool
     public let registeredUserCount: Int
     public let unregisteredUserCount: Int
+    public let tokenPresentCount: Int
+    /// Accounts the Platform SSO payload exempts from registration (`nonPlatformSSOAccounts`)
+    public let nonPlatformSSOAccounts: [String]
     public let users: [PlatformSSOUser]
-    
+
     public init(
         supported: Bool = false,
         deviceRegistered: Bool = false,
         registeredUserCount: Int = 0,
         unregisteredUserCount: Int = 0,
+        tokenPresentCount: Int = 0,
+        nonPlatformSSOAccounts: [String] = [],
         users: [PlatformSSOUser] = []
     ) {
         self.supported = supported
         self.deviceRegistered = deviceRegistered
         self.registeredUserCount = registeredUserCount
         self.unregisteredUserCount = unregisteredUserCount
+        self.tokenPresentCount = tokenPresentCount
+        self.nonPlatformSSOAccounts = nonPlatformSSOAccounts
         self.users = users
     }
 }
 
-/// Individual user's Platform SSO registration status
+/// Individual user's Platform SSO registration and token state
 public struct PlatformSSOUser: Codable, Sendable, Identifiable {
     public var id: String { username }
-    
+
     public let username: String
+    public let uid: Int?
     public let registered: Bool
+    /// Resolved from the Kerberos realm entry, e.g. `user@EXAMPLE.CA`
     public let userPrincipalName: String?
-    
+    /// Name shown by the SSO extension, masked by macOS as `u***r@example.ca`
+    public let loginUserName: String?
+    public let uniqueIdentifier: String?
+    /// Raw `POUserState*` value, e.g. `POUserStateNormal (0)`
+    public let state: String?
+    /// Raw `POLoginType*` value, e.g. `POLoginTypeUserSecureEnclaveKey (2)`
+    public let loginType: String?
+    public let lastLoginDate: String?
+    public let tokensPresent: Bool
+    public let tokenReceived: String?
+    public let tokenExpiration: String?
+    /// nil when no token is present, so "no token" stays distinct from "token valid"
+    public let tokenExpired: Bool?
+    /// Why the user was or was not probed: `ok`, `excluded`, `no-session`,
+    /// `device-not-registered`, `probe-failed`
+    public let probeStatus: String?
+
     public init(
         username: String,
+        uid: Int? = nil,
         registered: Bool = false,
-        userPrincipalName: String? = nil
+        userPrincipalName: String? = nil,
+        loginUserName: String? = nil,
+        uniqueIdentifier: String? = nil,
+        state: String? = nil,
+        loginType: String? = nil,
+        lastLoginDate: String? = nil,
+        tokensPresent: Bool = false,
+        tokenReceived: String? = nil,
+        tokenExpiration: String? = nil,
+        tokenExpired: Bool? = nil,
+        probeStatus: String? = nil
     ) {
         self.username = username
+        self.uid = uid
         self.registered = registered
         self.userPrincipalName = userPrincipalName
+        self.loginUserName = loginUserName
+        self.uniqueIdentifier = uniqueIdentifier
+        self.state = state
+        self.loginType = loginType
+        self.lastLoginDate = lastLoginDate
+        self.tokensPresent = tokensPresent
+        self.tokenReceived = tokenReceived
+        self.tokenExpiration = tokenExpiration
+        self.tokenExpired = tokenExpired
+        self.probeStatus = probeStatus
     }
 }
 

--- a/Sources/Models/Modules/IdentityModels.swift
+++ b/Sources/Models/Modules/IdentityModels.swift
@@ -8,7 +8,6 @@ public struct IdentityInfo: Codable, Sendable {
     public let groups: [UserGroup]
     public let loggedInUsers: [LoggedInUser]
     public let loginHistory: [LoginHistoryEntry]
-    public let btmdbHealth: BTMDBHealth
     public let directoryServices: DirectoryServicesInfo
     public let secureTokenUsers: SecureTokenInfo
     public let platformSSOUsers: PlatformSSOUsersInfo
@@ -19,7 +18,6 @@ public struct IdentityInfo: Codable, Sendable {
         groups: [UserGroup] = [],
         loggedInUsers: [LoggedInUser] = [],
         loginHistory: [LoginHistoryEntry] = [],
-        btmdbHealth: BTMDBHealth = BTMDBHealth(),
         directoryServices: DirectoryServicesInfo = DirectoryServicesInfo(),
         secureTokenUsers: SecureTokenInfo = SecureTokenInfo(),
         platformSSOUsers: PlatformSSOUsersInfo = PlatformSSOUsersInfo(),
@@ -29,7 +27,6 @@ public struct IdentityInfo: Codable, Sendable {
         self.groups = groups
         self.loggedInUsers = loggedInUsers
         self.loginHistory = loginHistory
-        self.btmdbHealth = btmdbHealth
         self.directoryServices = directoryServices
         self.secureTokenUsers = secureTokenUsers
         self.platformSSOUsers = platformSSOUsers
@@ -196,73 +193,6 @@ public struct LoginHistoryEntry: Codable, Sendable, Identifiable {
     }
 }
 
-// MARK: - BTMDB Health
-
-/// Background Task Management Database health status
-/// Critical for shared Mac environments where BTMDB corruption causes loginwindow deadlocks
-public struct BTMDBHealth: Codable, Sendable {
-    public let exists: Bool
-    public let path: String
-    public let sizeBytes: Int64
-    public let sizeMB: Double
-    public let status: BTMDBStatus
-    public let statusMessage: String
-    public let jetsamKillsLast7Days: Int
-    public let lastJetsamEvent: String?
-    public let registeredItemCount: Int
-    public let localUserCount: Int
-    public let thresholds: BTMDBThresholds
-    
-    public init(
-        exists: Bool = false,
-        path: String = "/private/var/db/com.apple.backgroundtaskmanagement",
-        sizeBytes: Int64 = 0,
-        sizeMB: Double = 0.0,
-        status: BTMDBStatus = .healthy,
-        statusMessage: String = "Database not found or not accessible",
-        jetsamKillsLast7Days: Int = 0,
-        lastJetsamEvent: String? = nil,
-        registeredItemCount: Int = 0,
-        localUserCount: Int = 0,
-        thresholds: BTMDBThresholds = BTMDBThresholds()
-    ) {
-        self.exists = exists
-        self.path = path
-        self.sizeBytes = sizeBytes
-        self.sizeMB = sizeMB
-        self.status = status
-        self.statusMessage = statusMessage
-        self.jetsamKillsLast7Days = jetsamKillsLast7Days
-        self.lastJetsamEvent = lastJetsamEvent
-        self.registeredItemCount = registeredItemCount
-        self.localUserCount = localUserCount
-        self.thresholds = thresholds
-    }
-}
-
-public enum BTMDBStatus: String, Codable, Sendable {
-    case healthy = "healthy"
-    case warning = "warning"
-    case critical = "critical"
-    case unknown = "unknown"
-}
-
-public struct BTMDBThresholds: Codable, Sendable {
-    public let warningMB: Double
-    public let criticalMB: Double
-    public let failureMB: Double
-    
-    public init(
-        warningMB: Double = 3.0,
-        criticalMB: Double = 3.5,
-        failureMB: Double = 4.0
-    ) {
-        self.warningMB = warningMB
-        self.criticalMB = criticalMB
-        self.failureMB = failureMB
-    }
-}
-
 // MARK: - Directory Services
 
 /// Directory service binding information
@@ -426,19 +356,16 @@ public struct IdentitySummary: Codable, Sendable {
     public let adminUsers: Int
     public let disabledUsers: Int
     public let currentlyLoggedIn: Int
-    public let btmdbStatus: String
-    
+
     public init(
         totalUsers: Int = 0,
         adminUsers: Int = 0,
         disabledUsers: Int = 0,
-        currentlyLoggedIn: Int = 0,
-        btmdbStatus: String = "unknown"
+        currentlyLoggedIn: Int = 0
     ) {
         self.totalUsers = totalUsers
         self.adminUsers = adminUsers
         self.disabledUsers = disabledUsers
         self.currentlyLoggedIn = currentlyLoggedIn
-        self.btmdbStatus = btmdbStatus
     }
 }

--- a/Sources/ReportMateClient.swift
+++ b/Sources/ReportMateClient.swift
@@ -574,6 +574,34 @@ struct ReportMateClient: AsyncParsableCommand {
 
     /// Path to the persistent boot time state file for reboot detection
     private static let previousBootTimePath = "/Library/Managed Reports/cache/previous_boot_time.json"
+
+    /// How far the reported boot time may move without being treated as a restart.
+    ///
+    /// `kern.boottime` is not a frozen constant: the kernel recalculates it whenever the system
+    /// clock is corrected, so it shifts by seconds across an NTP sync without anything having
+    /// restarted. A genuine reboot moves it forward by at least the previous uptime, which is
+    /// orders of magnitude larger, so a generous tolerance costs no real detections.
+    private static let bootTimeTolerance: TimeInterval = 300
+
+    /// The kernel's boot time as reported by the system module, if present.
+    ///
+    /// The system module publishes it under `systemDetails.bootTime`, sourced from
+    /// `sysctl kern.boottime`. The top level is checked too so a payload shape change does not
+    /// silently drop back to the derived value.
+    private static func reportedBootTime(from systemData: [String: Any]) -> Date? {
+        let candidates: [String?] = [
+            (systemData["systemDetails"] as? [String: Any])?["bootTime"] as? String,
+            systemData["bootTime"] as? String
+        ]
+
+        let formatter = ISO8601DateFormatter()
+        for case let value? in candidates where !value.isEmpty {
+            if let parsed = formatter.date(from: value) {
+                return parsed
+            }
+        }
+        return nil
+    }
     
     /// Detects OS version changes by comparing current system data against stored previous version.
     /// Returns a system event if the version changed, nil otherwise.
@@ -644,13 +672,29 @@ struct ReportMateClient: AsyncParsableCommand {
     /// Detects system reboots by comparing current uptime/boot time against stored previous boot time.
     /// Returns a system event if a reboot occurred, nil otherwise.
     private func detectReboot(systemData: [String: Any], logger: Logger) -> ReportMateEvent? {
-        // Calculate boot time from uptime seconds
-        let uptimeSeconds = systemData["uptime"] as? Int ?? 0
-        guard uptimeSeconds > 0 else { return nil }
-
-        let currentBootTime = Date().addingTimeInterval(-Double(uptimeSeconds))
-        let currentBootTimeStr = ISO8601DateFormatter().string(from: currentBootTime)
         let uptimeString = systemData["uptimeString"] as? String ?? ""
+        let uptimeSeconds = systemData["uptime"] as? Int ?? 0
+
+        // Use the kernel's own record of when the system came up. Deriving it as
+        // `now - uptime` re-derives a fixed instant from two values that are sampled at
+        // different moments: uptime is read early in the system module, while `now` is read
+        // here, after every module has finished collecting. The gap between them is the rest
+        // of the collection run, so the computed boot time slides forward by however long
+        // that took. Runs vary from seconds to minutes, so the value moves between every
+        // run and each move looks like a fresh reboot - which is why entire labs, all
+        // running the same schedule against the same slow modules, reported rebooting
+        // together when none of them had.
+        let currentBootTime: Date
+        if let bootTime = Self.reportedBootTime(from: systemData) {
+            currentBootTime = bootTime
+        } else if uptimeSeconds > 0 {
+            logger.info("No kernel boot time reported, falling back to uptime-derived boot time")
+            currentBootTime = Date().addingTimeInterval(-Double(uptimeSeconds))
+        } else {
+            return nil
+        }
+
+        let currentBootTimeStr = ISO8601DateFormatter().string(from: currentBootTime)
 
         // Read previous boot time state
         let fileURL = URL(fileURLWithPath: Self.previousBootTimePath)
@@ -681,10 +725,22 @@ struct ReportMateClient: AsyncParsableCommand {
             return nil
         }
 
-        // Boot time unchanged (within 60 second tolerance for clock drift)
-        guard abs(currentBootTime.timeIntervalSince(oldBootTime)) >= 60 else { return nil }
+        let delta = currentBootTime.timeIntervalSince(oldBootTime)
 
-        // Boot time changed — system was rebooted
+        // A reboot can only move boot time forward. Backwards movement is measurement error
+        // - a clock adjustment, or a previous run that recorded a value derived the old way -
+        // and never a restart, so it must never raise an event.
+        if delta <= -Self.bootTimeTolerance {
+            logger.info("Boot time moved backwards by \(Int(-delta))s; recording drift, not a reboot")
+            return nil
+        }
+
+        // Boot time unchanged, within tolerance for clock adjustments. kern.boottime is
+        // recalculated when the system clock is corrected, so it shifts by a few seconds
+        // without any restart.
+        guard delta >= Self.bootTimeTolerance else { return nil }
+
+        // Boot time moved forward — system was rebooted
         let message = "System reboot detected"
         logger.info(Logger.Message(stringLiteral: message))
 

--- a/Sources/ReportMateXPC/HelperXPCProtocol.swift
+++ b/Sources/ReportMateXPC/HelperXPCProtocol.swift
@@ -15,7 +15,7 @@ public let kHelperMachServiceName = "com.github.reportmate.helper"
 public let kReportMatePreferenceDomain = "com.github.reportmate"
 
 /// Path to the CLI binary inside the app bundle
-public let kReportMateCLIPath = "/Applications/Utilities/ReportMate.app/Contents/MacOS/managedreportsrunner"
+public let kReportMateCLIPath = "/Applications/Utilities/Managed Reports Runner.app/Contents/MacOS/managedreportsrunner"
 
 /// Helper LaunchDaemon plist name (used by SMAppService)
 public let kHelperPlistName = "com.github.reportmate.helper.plist"

--- a/Sources/Watcher/Database/AppUsageDatabase.swift
+++ b/Sources/Watcher/Database/AppUsageDatabase.swift
@@ -381,7 +381,36 @@ public final class AppUsageDatabase: @unchecked Sendable {
     }
     
     // MARK: - Maintenance
-    
+
+    /// Safety-net retention for completed sessions, in days. Sized to be far
+    /// longer than any normal transmit cadence (collection runs multiple times
+    /// daily) so the sweep never races legitimate untransmitted data — it only
+    /// removes sessions the transmit/confirm path has failed to retire for a
+    /// month.
+    public static let retentionDays = 30
+
+    /// Delete completed sessions whose end time is older than the cutoff,
+    /// regardless of transmitted state. This is an independent bound on
+    /// database and payload growth: it must fire even when the transmit or
+    /// confirm path is broken, which is exactly when transmitted stays false.
+    /// In-progress sessions (no end time) are never touched.
+    /// Returns the number of rows deleted.
+    @discardableResult
+    public func pruneExpiredSessions(olderThanDays days: Int = AppUsageDatabase.retentionDays) throws -> Int {
+        guard let db = db else {
+            throw AppUsageDatabaseError.notInitialized
+        }
+
+        let formatter = ISO8601DateFormatter()
+        let cutoff = formatter.string(from: Date(timeIntervalSinceNow: -Double(days) * 86_400))
+
+        // ISO8601 timestamps compare correctly as strings.
+        let expired = sessions
+            .filter(endTime != nil)
+            .filter(endTime < cutoff)
+        return try db.run(expired.delete())
+    }
+
     /// Get database statistics
     public func getStats() throws -> (totalSessions: Int, activeSessions: Int, transmittedPending: Int) {
         guard let db = db else {

--- a/Sources/Watcher/Watcher/AppUsageWatcher.swift
+++ b/Sources/Watcher/Watcher/AppUsageWatcher.swift
@@ -144,9 +144,9 @@ public final class AppUsageWatcher: @unchecked Sendable {
         let bundleId = app.bundleIdentifier
         let appName = app.localizedName ?? bundleURL.deletingPathExtension().lastPathComponent
         let path = bundleURL.path
-        let user = NSUserName()
         let pid = Int(app.processIdentifier)
-        
+        let user = processOwner(pid: pid) ?? NSUserName()
+
         logger.info("App launched: \(appName) (PID: \(pid))")
         
         do {
@@ -273,9 +273,9 @@ public final class AppUsageWatcher: @unchecked Sendable {
             let bundleId = app.bundleIdentifier
             let appName = app.localizedName ?? bundleURL.deletingPathExtension().lastPathComponent
             let path = bundleURL.path
-            let user = NSUserName()
             let pid = Int(app.processIdentifier)
-            
+            let user = processOwner(pid: pid) ?? NSUserName()
+
             // Try to get actual start time from process info
             let startTime = getProcessStartTime(pid: pid) ?? Date()
             
@@ -293,6 +293,42 @@ public final class AppUsageWatcher: @unchecked Sendable {
         logger.info("Reconciled \(appsToReconcile.count) running applications")
     }
     
+    /// The user a running process belongs to, or nil if it can't be determined.
+    ///
+    /// The watcher runs as a root LaunchDaemon, so `NSUserName()` reports the
+    /// daemon's own identity rather than the person at the keyboard. Reading the
+    /// owner from the observed process attributes each session to the right user
+    /// and stays correct across fast user switching. The uid is read rather than
+    /// `ps -o user=`, which truncates usernames past eight characters.
+    private func processOwner(pid: Int) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-o", "uid=", "-p", "\(pid)"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+
+            guard let output = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                  let uid = uid_t(output),
+                  let entry = getpwuid(uid) else {
+                return nil
+            }
+
+            let name = String(cString: entry.pointee.pw_name)
+            return name.isEmpty ? nil : name
+        } catch {
+            logger.debug("Could not resolve owner of PID \(pid): \(error)")
+            return nil
+        }
+    }
+
     /// Get process start time using ps command
     private func getProcessStartTime(pid: Int) -> Date? {
         let process = Process()

--- a/Sources/Watcher/Watcher/AppUsageWatcher.swift
+++ b/Sources/Watcher/Watcher/AppUsageWatcher.swift
@@ -24,6 +24,11 @@ public final class AppUsageWatcher: @unchecked Sendable {
     // Clamp on per-tick elapsed to defend against sleep/wake gaps (otherwise a
     // single tick after a 4-hour laptop sleep would charge 4 hours of fg time).
     private static let maxTickElapsed: TimeInterval = 90
+
+    // Retention sweep: a coarse daily timer prunes completed sessions older
+    // than the safety-net retention, independent of the transmit/confirm path.
+    private var pruneTimer: DispatchSourceTimer?
+    private static let pruneInterval: TimeInterval = 86_400
     
     // MARK: - Initialization
     
@@ -53,7 +58,11 @@ public final class AppUsageWatcher: @unchecked Sendable {
         // Mark any orphaned sessions from previous run
         try database.markOrphanedSessions()
         logger.info("Marked orphaned sessions from previous run")
-        
+
+        // Prune expired sessions once at startup, then daily via timer
+        runRetentionSweep()
+        startPruneTimer()
+
         // Reconcile with currently running apps
         try reconcileRunningApps()
         
@@ -77,6 +86,10 @@ public final class AppUsageWatcher: @unchecked Sendable {
         tickTimer?.cancel()
         tickTimer = nil
         lastTickAt = nil
+
+        // Cancel retention sweep timer
+        pruneTimer?.cancel()
+        pruneTimer = nil
 
         // Remove all observers
         let center = NSWorkspace.shared.notificationCenter
@@ -256,6 +269,34 @@ public final class AppUsageWatcher: @unchecked Sendable {
         }
     }
     
+    // MARK: - Retention Sweep
+
+    /// Start a coarse daily timer that prunes expired sessions. This is a
+    /// safety net against unbounded database growth if the transmit/confirm
+    /// path ever breaks again.
+    private func startPruneTimer() {
+        let queue = DispatchQueue(label: "com.reportmate.appusage.prune", qos: .utility)
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + Self.pruneInterval, repeating: Self.pruneInterval)
+        timer.setEventHandler { [weak self] in
+            self?.runRetentionSweep()
+        }
+        pruneTimer = timer
+        timer.resume()
+        logger.info("Retention sweep timer started (interval=\(Self.pruneInterval)s, retention=\(AppUsageDatabase.retentionDays)d)")
+    }
+
+    private func runRetentionSweep() {
+        do {
+            let pruned = try database.pruneExpiredSessions()
+            if pruned > 0 {
+                logger.info("Pruned \(pruned) completed sessions older than \(AppUsageDatabase.retentionDays) days")
+            }
+        } catch {
+            logger.error("Failed to prune expired sessions: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: - Reconciliation
     
     /// Reconcile database with currently running applications

--- a/build.sh
+++ b/build.sh
@@ -903,7 +903,11 @@ EOF
 </plist>
 EOF
 
-    # All-modules daemon - full collection every 12 hours
+    # All-modules daemon - full collection once daily in the 04:00-06:00 window.
+    # Full collection is expensive, so it must not run on a rolling StartInterval
+    # that drifts into working hours. launchd has no native trigger jitter, so the
+    # job is wrapped in a short shell that sleeps a random slice of the window;
+    # that spreads the fleet instead of every device hitting the API at 04:00.
     cat > "$APP_LAUNCHDAEMONS/com.github.reportmate.allmodules.plist" << 'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -913,10 +917,17 @@ EOF
     <string>com.github.reportmate.allmodules</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Applications/Utilities/ReportMate.app/Contents/MacOS/managedreportsrunner</string>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>sleep $(/usr/bin/jot -r 1 0 7200); exec /Applications/Utilities/ReportMate.app/Contents/MacOS/managedreportsrunner</string>
     </array>
-    <key>StartInterval</key>
-    <integer>43200</integer>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>4</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>
@@ -1007,9 +1018,10 @@ EOF
     },
     "allmodules": {
       "modules": "all",
-      "interval_seconds": 43200,
+      "calendar_interval": {"hour": 4, "minute": 0},
+      "random_delay_seconds": 7200,
       "launchd_label": "com.github.reportmate.allmodules",
-      "description": "Full collection of all modules every 12 hours"
+      "description": "Full collection of all modules once daily, spread randomly across the 04:00-06:00 maintenance window"
     }
   },
   "version": "1.0.0",

--- a/build.sh
+++ b/build.sh
@@ -1567,9 +1567,26 @@ fi
 if [ "$NOTARIZE" = true ] && [ "$SKIP_PKG" = false ]; then
     log_step "Submitting for notarization..."
     
-    # Validate notarization credentials are configured
-    if [ -z "$NOTARIZATION_APPLE_ID" ] || [ -z "$NOTARIZATION_PASSWORD" ] || [ -z "$TEAM_ID" ]; then
-        log_error "Notarization credentials not set. Please configure in .env:"
+    # Prefer a stored keychain profile. An app-specific password kept in .env is
+    # revoked whenever the Apple ID's password changes, and notarytool reports
+    # that as a bare "HTTP 401 ... not allowed for primary authentication" with
+    # no hint that the credential is simply dead. A keychain profile is
+    # validated once at creation and does not have to sit in a file.
+    if [ -n "$NOTARIZATION_KEYCHAIN_PROFILE" ]; then
+        NOTARY_AUTH=(--keychain-profile "$NOTARIZATION_KEYCHAIN_PROFILE")
+        log_info "Notarizing with keychain profile: $NOTARIZATION_KEYCHAIN_PROFILE"
+    elif [ -n "$NOTARIZATION_APPLE_ID" ] && [ -n "$NOTARIZATION_PASSWORD" ] && [ -n "$TEAM_ID" ]; then
+        NOTARY_AUTH=(--apple-id "$NOTARIZATION_APPLE_ID" --password "$NOTARIZATION_PASSWORD" --team-id "$TEAM_ID")
+        log_info "Notarizing with Apple ID: $NOTARIZATION_APPLE_ID"
+    else
+        log_error "Notarization credentials not set. Configure either in .env:"
+        log_info "  NOTARIZATION_KEYCHAIN_PROFILE=\"notarization_credentials\"   (preferred)"
+        log_info ""
+        log_info "  created once with:"
+        log_info "    xcrun notarytool store-credentials \"notarization_credentials\" \\\\"
+        log_info "      --apple-id \"your@email.com\" --team-id \"XXXXXXXXXX\" --password \"xxxx-xxxx-xxxx-xxxx\""
+        log_info ""
+        log_info "  or the legacy form:"
         log_info "  NOTARIZATION_APPLE_ID=\"your@email.com\""
         log_info "  NOTARIZATION_PASSWORD=\"xxxx-xxxx-xxxx-xxxx\""
         log_info "  TEAM_ID=\"XXXXXXXXXX\""
@@ -1577,15 +1594,10 @@ if [ "$NOTARIZE" = true ] && [ "$SKIP_PKG" = false ]; then
         log_info "Generate app-specific password at: https://appleid.apple.com/account/manage"
         exit 1
     fi
-    
+
     PKG_PATH="${DIST_DIR}/ReportMate-${VERSION}.pkg"
     
-    NOTARYTOOL_ARGS=(
-        --apple-id "$NOTARIZATION_APPLE_ID"
-        --password "$NOTARIZATION_PASSWORD"
-        --team-id "$TEAM_ID"
-        --wait
-    )
+    NOTARYTOOL_ARGS=("${NOTARY_AUTH[@]}" --wait)
     
     NOTARY_OUTPUT=$(xcrun notarytool submit "$PKG_PATH" "${NOTARYTOOL_ARGS[@]}" 2>&1)
     
@@ -1604,7 +1616,7 @@ if [ "$NOTARIZE" = true ] && [ "$SKIP_PKG" = false ]; then
         SUBMISSION_ID=$(echo "$NOTARY_OUTPUT" | grep "id:" | head -1 | awk '{print $2}')
         if [ -n "$SUBMISSION_ID" ]; then
             log_info "Getting detailed log..."
-            xcrun notarytool log "$SUBMISSION_ID" --apple-id "$NOTARIZATION_APPLE_ID" --password "$NOTARIZATION_PASSWORD" --team-id "$TEAM_ID"
+            xcrun notarytool log "$SUBMISSION_ID" "${NOTARY_AUTH[@]}"
         fi
         exit 1
     fi

--- a/build.sh
+++ b/build.sh
@@ -1290,13 +1290,31 @@ done
 for daemon in ${DAEMONS}; do
     source_path="${APP_ROOT}/Library/LaunchDaemons/${daemon}"
     dest_path="${LD_ROOT}/${daemon}"
-    
+    label="${daemon%.plist}"
+
     if [ -e "${source_path}" ]; then
         log_message "Installing: ${daemon}"
         cp "${source_path}" "${dest_path}"
         chmod 644 "${dest_path}"
         chown root:wheel "${dest_path}"
-        /bin/launchctl bootstrap system "${dest_path}"
+
+        # A `launchctl disable` is recorded in launchd's own override database
+        # (/var/db/com.apple.xpc.launchd/disabled.plist), keyed by label. That
+        # record is independent of the plist file, so removing and reinstalling
+        # the plist does not clear it, and bootstrap then fails with EIO for the
+        # life of the machine. Anyone who ever disabled a daemon to chase a
+        # performance problem would silently never get it back. Clear the
+        # override before bootstrapping.
+        /bin/launchctl enable "system/${label}" 2>/dev/null
+
+        if /bin/launchctl bootstrap system "${dest_path}" 2>/dev/null; then
+            log_message "Loaded: ${label}"
+        else
+            # Do not fail the install over one daemon, but never swallow it
+            # either - a daemon that silently fails to load is a module that
+            # silently stops being collected.
+            log_message "WARNING: failed to load ${label} - collection scheduled by this daemon will not run"
+        fi
     fi
 done
 

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,7 @@ fi
 # ═══════════════════════════════════════════════════════════════════════════
 
 PROJECT_NAME="ReportMate"
+APP_NAME="Managed Reports Runner"
 PRODUCT_NAME="managedreportsrunner"
 BUNDLE_ID="com.github.reportmate"
 PKG_IDENTIFIER="com.github.reportmate"
@@ -612,7 +613,7 @@ if [ "$SKIP_PKG" = false ]; then
     rm -rf "$PACKAGE_ROOT"
     
     # App bundle structure — installed to /Applications/Utilities/
-    APP_BUNDLE="${PACKAGE_ROOT}/Applications/Utilities/ReportMate.app"
+    APP_BUNDLE="${PACKAGE_ROOT}/Applications/Utilities/${APP_NAME}.app"
     APP_CONTENTS="${APP_BUNDLE}/Contents"
     APP_MACOS="${APP_CONTENTS}/MacOS"
     APP_RESOURCES="${APP_CONTENTS}/Resources"
@@ -666,7 +667,7 @@ if [ "$SKIP_PKG" = false ]; then
     cat > "$PACKAGE_ROOT/usr/local/reportmate/managedreportsrunner" << 'WRAPPER'
 #!/bin/sh
 # ReportMate CLI wrapper — forwards to app bundle in /Applications/Utilities/
-/Applications/Utilities/ReportMate.app/Contents/MacOS/managedreportsrunner "${@}"
+exec "/Applications/Utilities/Managed Reports Runner.app/Contents/MacOS/managedreportsrunner" "$@"
 WRAPPER
     chmod 755 "$PACKAGE_ROOT/usr/local/reportmate/managedreportsrunner"
 
@@ -722,7 +723,7 @@ WRAPPER
     # ═══════════════════════════════════════════════════════════════════════════
     # Vendor-neutral sample profile granting FDA + SysAdminFiles to the three
     # binaries in the collection chain (runner, osqueryi, macadmins extension).
-    # Shipped so admins can grab it from /Applications/Utilities/ReportMate.app/
+    # Shipped so admins can grab it from /Applications/Utilities/Managed Reports Runner.app/
     # Contents/Resources/profiles/ and adapt for their MDM.
 
     PPPC_SOURCE="${SCRIPT_DIR}/Sources/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig"
@@ -753,7 +754,9 @@ WRAPPER
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
-    <string>ReportMate</string>
+    <string>Managed Reports Runner</string>
+    <key>CFBundleDisplayName</key>
+    <string>Managed Reports Runner</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
@@ -787,7 +790,7 @@ EOF
     <string>com.github.reportmate.hourly</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Applications/Utilities/ReportMate.app/Contents/MacOS/managedreportsrunner</string>
+        <string>/Applications/Utilities/Managed Reports Runner.app/Contents/MacOS/managedreportsrunner</string>
         <string>--run-modules</string>
         <string>security,network,management,hardware</string>
         <string>--storage-mode</string>
@@ -828,7 +831,7 @@ EOF
     <string>com.github.reportmate.fourhourly</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Applications/Utilities/ReportMate.app/Contents/MacOS/managedreportsrunner</string>
+        <string>/Applications/Utilities/Managed Reports Runner.app/Contents/MacOS/managedreportsrunner</string>
         <string>--run-modules</string>
         <string>applications,inventory,system,identity,peripherals</string>
     </array>
@@ -867,7 +870,7 @@ EOF
     <string>com.github.reportmate.daily</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Applications/Utilities/ReportMate.app/Contents/MacOS/managedreportsrunner</string>
+        <string>/Applications/Utilities/Managed Reports Runner.app/Contents/MacOS/managedreportsrunner</string>
         <string>--run-modules</string>
         <string>hardware</string>
         <string>--storage-mode</string>
@@ -913,7 +916,7 @@ EOF
     <string>com.github.reportmate.allmodules</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Applications/Utilities/ReportMate.app/Contents/MacOS/managedreportsrunner</string>
+        <string>/Applications/Utilities/Managed Reports Runner.app/Contents/MacOS/managedreportsrunner</string>
     </array>
     <key>StartInterval</key>
     <integer>43200</integer>
@@ -1183,7 +1186,7 @@ EOF
 #!/bin/zsh
 # ReportMate Postinstall
 LD_ROOT="/Library/LaunchDaemons"
-APP_PATH="/Applications/Utilities/ReportMate.app"
+APP_PATH="/Applications/Utilities/Managed Reports Runner.app"
 APP_ROOT="${APP_PATH}/Contents"
 LOG_DIR="/Library/Managed Reports/logs"
 
@@ -1245,6 +1248,12 @@ OLD_APP="/usr/local/reportmate/ReportMate.app"
 if [ -d "$OLD_APP" ]; then
     log_message "Removing old app bundle at ${OLD_APP}"
     rm -rf "$OLD_APP"
+fi
+
+# Remove the pre-rename bundle from /Applications/Utilities
+if [ -d "/Applications/Utilities/ReportMate.app" ]; then
+    log_message "Removing old app bundle at /Applications/Utilities/ReportMate.app"
+    rm -rf "/Applications/Utilities/ReportMate.app"
 fi
 
 # Remove numbered duplicates created by macOS Installer relocation
@@ -1461,6 +1470,12 @@ if [ -d "$OLD_APP" ]; then
     log_message "Removing old app bundle at ${OLD_APP}"
     rm -rf "$OLD_APP"
 fi
+
+# Remove the pre-rename bundle from /Applications/Utilities
+if [ -d "/Applications/Utilities/ReportMate.app" ]; then
+    log_message "Removing old app bundle at /Applications/Utilities/ReportMate.app"
+    rm -rf "/Applications/Utilities/ReportMate.app"
+fi
 setopt NULL_GLOB 2>/dev/null
 for dup in /usr/local/reportmate/ReportMate-*.localized; do
     [ -e "$dup" ] && { log_message "Removing duplicate: $dup"; rm -rf "$dup"; }
@@ -1490,7 +1505,7 @@ PREINSTALL_SCRIPT
         <key>BundleOverwriteAction</key>
         <string>upgrade</string>
         <key>RootRelativeBundlePath</key>
-        <string>Applications/Utilities/ReportMate.app</string>
+        <string>Applications/Utilities/Managed Reports Runner.app</string>
     </dict>
 </array>
 </plist>

--- a/docs/MUNKI_INTEGRATION.md
+++ b/docs/MUNKI_INTEGRATION.md
@@ -85,7 +85,7 @@ graph TD
 - Logs execution to `/Library/Managed Reports/logs/munki-postflight.log`
 - Non-blocking: failure in one script doesn't prevent others from running
 
-**Source:** Bundled in `ReportMate.app/Contents/Resources/munki/postflight-wrapper`
+**Source:** Bundled in `Managed Reports Runner.app/Contents/Resources/munki/postflight-wrapper`
 
 #### 00-original.sh (MunkiReport)
 
@@ -120,7 +120,7 @@ graph TD
 - Homebrew packages
 - App Store apps
 
-**Source:** Bundled in `ReportMate.app/Contents/Resources/munki/reportmate.sh`
+**Source:** Bundled in `Managed Reports Runner.app/Contents/Resources/munki/reportmate.sh`
 
 ## Coexistence Benefits
 
@@ -247,7 +247,7 @@ head -5 /usr/local/munki/postflight
 **Fix:**
 ```bash
 # Reinstall ReportMate.pkg or manually copy wrapper
-sudo cp /usr/local/reportmate/ReportMate.app/Contents/Resources/munki/postflight-wrapper \
+sudo cp "/Applications/Utilities/Managed Reports Runner.app/Contents/Resources/munki/postflight-wrapper" \
         /usr/local/munki/postflight
 sudo chmod 755 /usr/local/munki/postflight
 sudo chown root:wheel /usr/local/munki/postflight


### PR DESCRIPTION
The app bundle becomes /Applications/Utilities/Managed Reports Runner.app (display name 'Managed Reports Runner'), uniform with Managed Software Center (Munki/Cimian) and Managed Bootstrap Install (BootstrapMate). Stays in /Applications/Utilities. The Windows client PR renames ReportMate.exe the same way.

Unchanged on purpose:
- CLI binary managedreportsrunner (inside the bundle) and the /usr/local/reportmate symlink
- Bundle id com.github.reportmate and every derived identifier — the FDA/PPPC profile keys on the codesign identifier, not the path, so the grant survives
- ReportMate-<version>.pkg/.zip/.dmg artifact names (release workflow regexes and Munki pkgsinfo depend on them)
- Icon asset name ReportMate, entitlements filenames

Transition: pre/postinstall remove the old /Applications/Utilities/ReportMate.app; the /usr/local/bin wrapper now quotes the spaced bundle path; component plist RootRelativeBundlePath updated in lockstep so relocation suppression holds.

Heads-up for deployers: Munki-side consumers reference the old path (ReportMateConfig postinstall, LogDeck detection paths) — being updated in lockstep in the Devices/Munki repo.

AB#4264