### PR TITLE
Prune watcher sessions older than 30 days as an unbounded-growth safety net

### DIFF
--- a/Sources/Watcher/Database/AppUsageDatabase.swift
+++ b/Sources/Watcher/Database/AppUsageDatabase.swift
@@ -381,7 +381,36 @@ public final class AppUsageDatabase: @unchecked Sendable {
     }
     
     // MARK: - Maintenance
-    
+
+    /// Safety-net retention for completed sessions, in days. Sized to be far
+    /// longer than any normal transmit cadence (collection runs multiple times
+    /// daily) so the sweep never races legitimate untransmitted data — it only
+    /// removes sessions the transmit/confirm path has failed to retire for a
+    /// month.
+    public static let retentionDays = 30
+
+    /// Delete completed sessions whose end time is older than the cutoff,
+    /// regardless of transmitted state. This is an independent bound on
+    /// database and payload growth: it must fire even when the transmit or
+    /// confirm path is broken, which is exactly when transmitted stays false.
+    /// In-progress sessions (no end time) are never touched.
+    /// Returns the number of rows deleted.
+    @discardableResult
+    public func pruneExpiredSessions(olderThanDays days: Int = AppUsageDatabase.retentionDays) throws -> Int {
+        guard let db = db else {
+            throw AppUsageDatabaseError.notInitialized
+        }
+
+        let formatter = ISO8601DateFormatter()
+        let cutoff = formatter.string(from: Date(timeIntervalSinceNow: -Double(days) * 86_400))
+
+        // ISO8601 timestamps compare correctly as strings.
+        let expired = sessions
+            .filter(endTime != nil)
+            .filter(endTime < cutoff)
+        return try db.run(expired.delete())
+    }
+
     /// Get database statistics
     public func getStats() throws -> (totalSessions: Int, activeSessions: Int, transmittedPending: Int) {
         guard let db = db else {

--- a/Sources/Watcher/Watcher/AppUsageWatcher.swift
+++ b/Sources/Watcher/Watcher/AppUsageWatcher.swift
@@ -24,6 +24,11 @@ public final class AppUsageWatcher: @unchecked Sendable {
     // Clamp on per-tick elapsed to defend against sleep/wake gaps (otherwise a
     // single tick after a 4-hour laptop sleep would charge 4 hours of fg time).
     private static let maxTickElapsed: TimeInterval = 90
+
+    // Retention sweep: a coarse daily timer prunes completed sessions older
+    // than the safety-net retention, independent of the transmit/confirm path.
+    private var pruneTimer: DispatchSourceTimer?
+    private static let pruneInterval: TimeInterval = 86_400
     
     // MARK: - Initialization
     
@@ -53,7 +58,11 @@ public final class AppUsageWatcher: @unchecked Sendable {
         // Mark any orphaned sessions from previous run
         try database.markOrphanedSessions()
         logger.info("Marked orphaned sessions from previous run")
-        
+
+        // Prune expired sessions once at startup, then daily via timer
+        runRetentionSweep()
+        startPruneTimer()
+
         // Reconcile with currently running apps
         try reconcileRunningApps()
         
@@ -77,6 +86,10 @@ public final class AppUsageWatcher: @unchecked Sendable {
         tickTimer?.cancel()
         tickTimer = nil
         lastTickAt = nil
+
+        // Cancel retention sweep timer
+        pruneTimer?.cancel()
+        pruneTimer = nil
 
         // Remove all observers
         let center = NSWorkspace.shared.notificationCenter
@@ -256,6 +269,34 @@ public final class AppUsageWatcher: @unchecked Sendable {
         }
     }
     
+    // MARK: - Retention Sweep
+
+    /// Start a coarse daily timer that prunes expired sessions. This is a
+    /// safety net against unbounded database growth if the transmit/confirm
+    /// path ever breaks again.
+    private func startPruneTimer() {
+        let queue = DispatchQueue(label: "com.reportmate.appusage.prune", qos: .utility)
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + Self.pruneInterval, repeating: Self.pruneInterval)
+        timer.setEventHandler { [weak self] in
+            self?.runRetentionSweep()
+        }
+        pruneTimer = timer
+        timer.resume()
+        logger.info("Retention sweep timer started (interval=\(Self.pruneInterval)s, retention=\(AppUsageDatabase.retentionDays)d)")
+    }
+
+    private func runRetentionSweep() {
+        do {
+            let pruned = try database.pruneExpiredSessions()
+            if pruned > 0 {
+                logger.info("Pruned \(pruned) completed sessions older than \(AppUsageDatabase.retentionDays) days")
+            }
+        } catch {
+            logger.error("Failed to prune expired sessions: \(error.localizedDescription)")
+        }
+    }
+
     // MARK: - Reconciliation
     
     /// Reconcile database with currently running applications


### PR DESCRIPTION
AB#4245 — independent safety net against the failure mode that inflated server data for months: confirmTransmission() was never called, nothing pruned the watcher DB, and every Mac re-sent its entire session history each cycle. PR #12 fixed the confirm path; this bounds the damage if that path (or transmit itself) ever breaks again.

- AppUsageDatabase.pruneExpiredSessions(olderThanDays:) deletes completed sessions whose end_time is older than 30 days regardless of transmitted state — deliberately, since transmitted staying false is exactly the broken-path symptom. In-progress sessions (end_time NULL) are never touched. end_time is ISO8601 UTC strings throughout the schema, so the string comparison is sound.
- 30-day retention is sized far beyond any normal transmit cadence (collection runs multiple times daily), so the sweep can never race legitimate untransmitted data.
- AppUsageWatcher runs the sweep once at startup (right after markOrphanedSessions, so orphans stamped with an end time age out) and daily via a DispatchSourceTimer matching the existing tick-timer pattern; cancelled in stop(); logs only nonzero prune counts.

swift build passes clean.

Do not deploy yet — ships with the rest of the AB#4241 hardening batch.