### PR TITLE
Stop sending the unknown-duration sentinel as negative seconds

### DIFF
--- a/Sources/DataCollection/Services/ApplicationUsageService.swift
+++ b/Sources/DataCollection/Services/ApplicationUsageService.swift
@@ -426,14 +426,19 @@ public class ApplicationUsageService: @unchecked Sendable {
 
             let users = Array(Set(grouped.map { $0.user }.filter { !$0.isEmpty }))
 
+            // A session interrupted by a watcher restart is stamped with the -1
+            // unknown-duration sentinel (AppUsageDatabase.markOrphanedSessions).
+            // It carries no measurable duration, so it contributes nothing here —
+            // summing it raw would send a negative total to the server, which
+            // reads these as real seconds and accumulates them.
             summaries.append([
                 "date": dateStr,
                 "appName": appName,
                 "publisher": "",
                 "launches": grouped.count,
-                "totalSeconds": grouped.reduce(0.0) { $0 + $1.durationSeconds },
-                "foregroundSeconds": grouped.reduce(0.0) { $0 + $1.foregroundSeconds },
-                "activeSeconds": grouped.reduce(0.0) { $0 + $1.activeSeconds },
+                "totalSeconds": grouped.reduce(0.0) { $0 + max(0, $1.durationSeconds) },
+                "foregroundSeconds": grouped.reduce(0.0) { $0 + max(0, $1.foregroundSeconds) },
+                "activeSeconds": grouped.reduce(0.0) { $0 + max(0, $1.activeSeconds) },
                 "users": users
             ])
         }


### PR DESCRIPTION
AB#4423 — macOS daily usage rows reach the API with negative `totalSeconds`. Windows has none.

## Root cause

`AppUsageDatabase.markOrphanedSessions` stamps every in-progress session with `end_time = now` and `duration_seconds = -1` when the watcher restarts, so the sentinel exists on any Mac that has rebooted with background apps running — which is why the affected apps are exactly the long-lived ones (Creative Cloud, Wacom drivers, OneDrive, XCreds).

`collectFromDatabase` honours the sentinel when accumulating `totalUsageSeconds` (`if row[durationCol] != -1`), but `buildDailySummaries` summed `durationSeconds` raw. Orphaned sessions have an `end_time`, so they are not `isActive` and do pass the filter into the daily rollup — the -1 reached the server as a real measurement and was accumulated.

## Why it matters now

The magnitude is trivial on its own: about -1 second per device-day. The hazard is the interaction with **reportmate-api PR #38** (AB#4253), which rejects an *entire* `dailyUsageHistory` row when any number is negative (`_usage_entry_numbers` returns `None` on `min(values) < 0`). Shipping that against today's clients would silently discard correct foreground and active data along with the sentinel.

Measured on prod, 7-day window, ~50 apps affected:

| App | Devices | foreground-h at risk | totalSeconds |
|---|---|---|---|
| XCreds Login Overlay | 21 | 120.0 | -98 |
| UserClient | 43 | 31.6 | -185 |
| Creative Cloud Content Manager | 53 | — | -197 |
| Adobe Content Synchronizer | 44 | — | -180 |

## Fix

Clamp all three duration counters where they enter the daily rollup, matching the guard `collectFromDatabase` already applies. The sentinel is left intact on the session model, where `isUnknownDuration` still gives it meaning.

## Verification

`swift build` clean (with the `build.sh`-generated `ModuleVersions.swift` placeholder — a bare `swift build` fails on `main` without it, unrelated to this change).

Traced the path end to end: `markOrphanedSessions` sets `end_time`, so `isActive` is false, so the session passes the `!isActive` filter at the top of `buildDailySummaries` and is summed — confirming the sentinel does reach the payload and that this is the right interception point.

## Sequencing

**This must deploy before reportmate-api PR #38**, or PR #38 must clamp instead of reject.