### PR TITLE
Attribute a session to every day it spans, not just its start date

### DIFF
--- a/Sources/DataCollection/Services/ApplicationUsageService.swift
+++ b/Sources/DataCollection/Services/ApplicationUsageService.swift
@@ -392,6 +392,57 @@ public class ApplicationUsageService: @unchecked Sendable {
         return nil
     }
 
+    /// Running totals for one (date, app name) pair while summaries are built.
+    private struct DailyUsageBucket {
+        var launches = 0
+        var totalSeconds = 0.0
+        var foregroundSeconds = 0.0
+        var activeSeconds = 0.0
+        var users: Set<String> = []
+    }
+
+    /// The calendar days a session covers, each with the fraction of the
+    /// session's wall-clock span that fell on that day.
+    ///
+    /// A session is one continuous run of an application, so an app opened
+    /// before midnight and closed after it was in use on both days. Attributing
+    /// the whole run to the day it started — as this did previously — books a
+    /// week of uptime onto a single date and leaves the days it actually
+    /// covered empty, which makes any per-day or per-week series wrong.
+    ///
+    /// The foreground and active counters are accumulated across the whole
+    /// session rather than per day, so they are apportioned by the same
+    /// wall-clock share. That is an estimate; only per-day counters in the
+    /// watcher itself could make it exact.
+    private func daySpans(of session: ApplicationUsageSession,
+                          formatter: DateFormatter) -> [(String, Double)] {
+        let start = session.startTime
+        guard let end = session.endTime, end > start else {
+            return [(formatter.string(from: start), 1.0)]
+        }
+
+        let span = end.timeIntervalSince(start)
+        let calendar = Calendar.current
+        var spans: [(String, Double)] = []
+        var cursor = start
+
+        // Bounded by the watcher's 30-day retention; the cap only guards against
+        // a corrupt end_time far in the future turning this into a long loop.
+        while cursor < end, spans.count < 400 {
+            let dayStart = calendar.startOfDay(for: cursor)
+            guard let nextDay = calendar.date(byAdding: .day, value: 1, to: dayStart),
+                  nextDay > cursor else { break }
+            let segmentEnd = min(nextDay, end)
+            let seconds = segmentEnd.timeIntervalSince(cursor)
+            if seconds > 0 {
+                spans.append((formatter.string(from: cursor), seconds / span))
+            }
+            cursor = segmentEnd
+        }
+
+        return spans.isEmpty ? [(formatter.string(from: start), 1.0)] : spans
+    }
+
     /// Build daily per-application usage summaries from sessions.
     /// Groups by (date, app name). Cumulative: last collection of the day wins (UPSERT on API).
     public func buildDailySummaries(sessions: [ApplicationUsageSession]) -> [[String: Any]] {
@@ -409,37 +460,54 @@ public class ApplicationUsageService: @unchecked Sendable {
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.timeZone = TimeZone.current
 
-        // Group by (date string, app name)
-        var groups: [String: [ApplicationUsageSession]] = [:]
+        // Accumulate by (date string, app name). A session that runs past
+        // midnight belongs to every day it covers, not only the one it started
+        // on, so each session is split across the days it spans first.
+        var buckets: [String: DailyUsageBucket] = [:]
         for session in sessions {
-            let dateStr = dateFormatter.string(from: session.startTime)
-            let key = "\(dateStr)||\(session.name)"
-            groups[key, default: []].append(session)
-        }
-
-        var summaries: [[String: Any]] = []
-        for (key, grouped) in groups {
-            let parts = key.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
-            guard parts.count >= 3 else { continue }
-            let dateStr = String(parts[0])
-            let appName = String(parts[2])
-
-            let users = Array(Set(grouped.map { $0.user }.filter { !$0.isEmpty }))
-
             // A session interrupted by a watcher restart is stamped with the -1
             // unknown-duration sentinel (AppUsageDatabase.markOrphanedSessions).
             // It carries no measurable duration, so it contributes nothing here —
             // summing it raw would send a negative total to the server, which
             // reads these as real seconds and accumulates them.
+            let total = max(0, session.durationSeconds)
+            let foreground = max(0, session.foregroundSeconds)
+            let active = max(0, session.activeSeconds)
+            let startDate = dateFormatter.string(from: session.startTime)
+
+            for (dateStr, share) in daySpans(of: session, formatter: dateFormatter) {
+                let key = "\(dateStr)||\(session.name)"
+                var bucket = buckets[key] ?? DailyUsageBucket()
+                bucket.totalSeconds += total * share
+                bucket.foregroundSeconds += foreground * share
+                bucket.activeSeconds += active * share
+                if !session.user.isEmpty {
+                    bucket.users.insert(session.user)
+                }
+                // One app-open is one launch, counted on the day it happened —
+                // apportioning it too would multiply launch counts by the number
+                // of days a long-running app happened to stay open.
+                if dateStr == startDate {
+                    bucket.launches += 1
+                }
+                buckets[key] = bucket
+            }
+        }
+
+        var summaries: [[String: Any]] = []
+        for (key, bucket) in buckets {
+            let parts = key.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
+            guard parts.count >= 3 else { continue }
+
             summaries.append([
-                "date": dateStr,
-                "appName": appName,
+                "date": String(parts[0]),
+                "appName": String(parts[2]),
                 "publisher": "",
-                "launches": grouped.count,
-                "totalSeconds": grouped.reduce(0.0) { $0 + max(0, $1.durationSeconds) },
-                "foregroundSeconds": grouped.reduce(0.0) { $0 + max(0, $1.foregroundSeconds) },
-                "activeSeconds": grouped.reduce(0.0) { $0 + max(0, $1.activeSeconds) },
-                "users": users
+                "launches": bucket.launches,
+                "totalSeconds": bucket.totalSeconds,
+                "foregroundSeconds": bucket.foregroundSeconds,
+                "activeSeconds": bucket.activeSeconds,
+                "users": Array(bucket.users)
             ])
         }
 


### PR DESCRIPTION
AB#4424 — `buildDailySummaries` grouped on the date of `session.startTime` and summed the whole run there, so an application left open across several days booked its entire lifetime onto day one and contributed nothing to the days it actually covered.

Independent of the re-send inflation fixed in #12, and it survived that fix. Invisible in 7-day aggregates — which is why the earlier accuracy checks did not surface it — but it corrupts any per-day or per-week series, which is exactly what the April faculty and dean reporting (AB#4261) is built on.

Visible on prod today on current-build machines: KLJTW0H6C1 at 121 total-hours/device/day, DW16LW76VG at 118.

## Fix

Split each session across the calendar days between its start and end, apportioning the duration counters by each day's share of the wall-clock span.

One app-open stays one launch, counted on the day it happened — apportioning launches too would multiply counts by how long an app happened to stay open.

`foregroundSeconds`/`activeSeconds` are accumulated per session rather than per day, so splitting them by the same wall-clock share is an **estimate**. Making it exact needs per-day counters in the watcher itself; noted in the helper's doc comment as the follow-up.

## Verification

`swift build` clean. Behaviour verified against a standalone harness that runs the helper and the accumulation verbatim — 22 checks, all passing:

| Case | Result |
|---|---|
| Same-day session (regression guard) | unchanged: 1 row, 8h intact, 1 launch |
| Crosses midnight 22:00→02:00 | 2h/2h split, foreground 1h/1h, launch only on start day |
| The H2WHX1E1Q6NY shape (446h run) | 19 days, **no day over 24h**, total conserved, foreground peak 80h → 4.3h |
| Orphaned session (-1 sentinel) | no negative emitted, all zero |
| Missing `end_time` | falls back to start date, duration kept |
| Two sessions of one app in a day | merge to 1 row, 2 launches, 2h |
| DST 25-hour day (2026-11-01) | total conserved |

The harness is scratch, not committed — this repo has no test target.

## Note

Fixes data going forward only. Rows already in `usage_history` keep the old attribution and are cleared by the AB#4256 baseline reset.