### PR TITLE
Report Platform SSO per-user registration and token state accurately

### DIFF
--- a/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
@@ -638,100 +638,269 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
     
     // MARK: - Platform SSO Users (user-level SSO registration status)
     
-    /// Collects Platform SSO user registration status
-    /// This focuses on per-user SSO registration, complementing the device-level config in Security module
+    /// Collects Platform SSO per-user registration and token state.
+    ///
+    /// `app-sso platform -s` prints four sections: a device-level `Device Configuration`
+    /// block, a `Login Configuration` block, a per-user `User Configuration` block, and a
+    /// plain-text `SSO Tokens` trailer. Two properties of that output drive this collector:
+    ///
+    /// 1. `registrationCompleted` is device-level. It prints identically for every account,
+    ///    including accounts that have never registered, so it can never be used to decide
+    ///    whether a *user* is registered. Per-user truth is a populated `User Configuration`
+    ///    block, and the token state is the `SSO Tokens` trailer.
+    /// 2. Platform SSO state is only reachable inside the user's Aqua session. Probing a user
+    ///    with no GUI session blocks indefinitely, so every account is gated on an active
+    ///    `gui/<uid>` launchd domain and every invocation carries a hard timeout.
     private func collectPlatformSSOUsers() async throws -> [String: Any] {
         let bashScript = """
-            # Platform SSO user registration status (macOS 13+ Ventura)
-            # Focuses on per-user SSO registration for Identity module
-            
-            # Check macOS version (Platform SSO requires 13+)
-            os_version=$(sw_vers -productVersion | cut -d. -f1)
-            if [ "$os_version" -lt 13 ]; then
+            # Platform SSO per-user registration and token state (macOS 13+ Ventura)
+            set -m
+
+            APPSSO="/usr/bin/app-sso"
+
+            emit_unsupported() {
                 echo "{"
                 echo "  \\"supported\\": false,"
-                echo "  \\"users\\": []"
-                echo "}"
-                exit 0
-            fi
-            
-            # Get device SSO state to check if Platform SSO is configured
-            sso_state=$(app-sso platform -s 2>/dev/null || echo "")
-            registered="false"
-            
-            if [ -n "$sso_state" ]; then
-                if echo "$sso_state" | grep -q '"registrationCompleted" *: *true'; then
-                    registered="true"
-                fi
-            fi
-            
-            if [ "$registered" != "true" ]; then
-                echo "{"
-                echo "  \\"supported\\": true,"
                 echo "  \\"deviceRegistered\\": false,"
+                echo "  \\"registeredUserCount\\": 0,"
+                echo "  \\"unregisteredUserCount\\": 0,"
+                echo "  \\"tokenPresentCount\\": 0,"
+                echo "  \\"nonPlatformSSOAccounts\\": [],"
                 echo "  \\"users\\": []"
                 echo "}"
+            }
+
+            os_major=$(sw_vers -productVersion 2>/dev/null | cut -d. -f1)
+            case "$os_major" in
+                ''|*[!0-9]*) emit_unsupported; exit 0 ;;
+            esac
+            if [ "$os_major" -lt 13 ] || [ ! -x "$APPSSO" ]; then
+                emit_unsupported
                 exit 0
             fi
-            
-            # Collect per-user SSO registration status
+
+            # Run a command under a hard wall-clock limit, killing its whole process group on
+            # expiry. app-sso blocks forever against a user with no GUI session, and output is
+            # staged through a temp file so a surviving grandchild can never hold our stdout
+            # pipe open.
+            run_with_timeout() {
+                _limit=$1
+                shift
+                _out=$(mktemp /tmp/reportmate-psso.XXXXXX) || return 1
+                "$@" >"$_out" 2>/dev/null &
+                _pid=$!
+                _waited=0
+                while kill -0 "$_pid" 2>/dev/null; do
+                    if [ "$_waited" -ge "$_limit" ]; then
+                        kill -9 -"$_pid" 2>/dev/null
+                        kill -9 "$_pid" 2>/dev/null
+                        wait "$_pid" 2>/dev/null
+                        rm -f "$_out"
+                        return 124
+                    fi
+                    sleep 1
+                    _waited=$((_waited + 1))
+                done
+                wait "$_pid" 2>/dev/null
+                cat "$_out"
+                rm -f "$_out"
+                return 0
+            }
+
+            # Values here are UPNs, UUIDs, ISO dates and enum strings. None legitimately
+            # contain a quote or backslash once unescaped, so dropping those keeps the
+            # hand-assembled JSON well formed.
+            json_scrub() {
+                printf '%s' "$1" | tr -d '\\\\"' | tr -d '\\r\\n\\t'
+            }
+
+            # First "key" : "value" pair in the text on stdin.
+            json_string() {
+                grep "\\"$1\\"" | head -1 | sed 's/.*: *"\\(.*\\)".*/\\1/'
+            }
+
+            running_uid=$(id -u)
+
+            # --- Device configuration ---------------------------------------------
+            device_state=$(run_with_timeout 20 "$APPSSO" platform -s)
+            device_section=$(printf '%s\\n' "$device_state" | awk '/^Device Configuration:/{f=1;next} f&&/^Login Configuration:/{f=0} f')
+
+            device_registered="false"
+            if printf '%s\\n' "$device_section" | grep -q '"registrationCompleted" *: *true'; then
+                device_registered="true"
+            fi
+
+            # Accounts the PSSO payload exempts by policy. Never probe these: they have no SSO
+            # agent, so app-sso would hang against them.
+            non_psso_accounts=$(printf '%s\\n' "$device_section" \\
+                | sed -n '/"nonPlatformSSOAccounts"/,/]/p' \\
+                | grep -v 'nonPlatformSSOAccounts' \\
+                | sed -n 's/.*"\\([^"]*\\)".*/\\1/p')
+
+            non_psso_json="["
+            first_np="true"
+            for acct in $non_psso_accounts; do
+                [ "$first_np" = "true" ] && first_np="false" || non_psso_json="$non_psso_json,"
+                non_psso_json="$non_psso_json\\"$(json_scrub "$acct")\\""
+            done
+            non_psso_json="$non_psso_json]"
+
+            is_non_psso_account() {
+                for acct in $non_psso_accounts; do
+                    [ "$acct" = "$1" ] && return 0
+                done
+                return 1
+            }
+
+            has_gui_session() {
+                if [ "$running_uid" = "$1" ]; then
+                    return 0
+                fi
+                launchctl print "gui/$1" >/dev/null 2>&1
+            }
+
+            appsso_for_user() {
+                if [ "$running_uid" = "0" ]; then
+                    run_with_timeout 20 launchctl asuser "$2" sudo -u "$1" "$APPSSO" platform -s
+                elif [ "$running_uid" = "$2" ]; then
+                    run_with_timeout 20 "$APPSSO" platform -s
+                else
+                    return 1
+                fi
+            }
+
             users_json="["
             first_user="true"
             registered_count=0
             unregistered_count=0
-            
-            # Get all human users
-            for user in $(dscl . -list /Users | grep -v "^_" | grep -v "daemon\\|nobody\\|root\\|Guest"); do
-                user_home=$(dscl . -read /Users/"$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}' || echo "")
-                if [ ! -d "$user_home" ] || [ "$user_home" = "/var/empty" ]; then
-                    continue
-                fi
-                
-                # Run app-sso as the user to get their SSO status
-                user_sso=$(sudo -u "$user" app-sso platform -s 2>/dev/null || echo "")
-                
-                user_registered="false"
-                user_upn=""
-                last_auth=""
-                
-                if [ -n "$user_sso" ]; then
-                    if echo "$user_sso" | grep -q '"registrationCompleted" *: *true'; then
-                        user_registered="true"
-                        registered_count=$((registered_count + 1))
+            token_count=0
+
+            for user in $(dscl . -list /Users UniqueID 2>/dev/null | awk '$2 >= 500 && $2 < 65534 {print $1}'); do
+                uid=$(dscl . -read "/Users/$user" UniqueID 2>/dev/null | awk '{print $2}')
+                [ -z "$uid" ] && continue
+
+                home=$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}')
+                case "$home" in
+                    ''|/var/empty|/dev/null) continue ;;
+                esac
+
+                registered="false"
+                upn=""
+                login_user_name=""
+                unique_id=""
+                user_state=""
+                login_type=""
+                last_login=""
+                token_received=""
+                token_expiration=""
+                token_expired="null"
+                has_tokens="false"
+                probe_status="ok"
+
+                if is_non_psso_account "$user"; then
+                    probe_status="excluded"
+                elif [ "$device_registered" != "true" ]; then
+                    probe_status="device-not-registered"
+                elif ! has_gui_session "$uid"; then
+                    probe_status="no-session"
+                else
+                    user_output=$(appsso_for_user "$user" "$uid")
+                    if [ $? -ne 0 ] || [ -z "$user_output" ]; then
+                        probe_status="probe-failed"
                     else
-                        unregistered_count=$((unregistered_count + 1))
+                        user_section=$(printf '%s\\n' "$user_output" \\
+                            | awk '/^User Configuration:/{f=1;next} f&&/^SSO Tokens:/{f=0} f')
+                        token_section=$(printf '%s\\n' "$user_output" | sed -n '/^SSO Tokens:/,$p')
+
+                        unique_id=$(printf '%s\\n' "$user_section" | json_string uniqueIdentifier)
+                        user_state=$(printf '%s\\n' "$user_section" | json_string state)
+                        login_type=$(printf '%s\\n' "$user_section" | json_string loginType)
+                        last_login=$(printf '%s\\n' "$user_section" | json_string lastLoginDate)
+                        login_user_name=$(printf '%s\\n' "$user_section" | json_string loginUserName)
+
+                        # The real UPN lives in kerberosStatus, not in a userPrincipalName key
+                        # (no such key exists). Prefer the on-prem realm entry; the cloud entry
+                        # escapes the local part and appends the Kerberos realm, so unwrap it
+                        # as a fallback.
+                        upn=$(printf '%s\\n' "$user_section" | grep '"upn"' \\
+                            | grep -v 'KERBEROS.MICROSOFTONLINE.COM' | head -1 \\
+                            | sed 's/.*: *"\\(.*\\)".*/\\1/')
+                        if [ -z "$upn" ]; then
+                            upn=$(printf '%s\\n' "$user_section" | grep '"upn"' | head -1 \\
+                                | sed 's/.*: *"\\(.*\\)".*/\\1/' \\
+                                | sed 's/@KERBEROS\\.MICROSOFTONLINE\\.COM$//' \\
+                                | sed 's/\\\\@/@/g')
+                        fi
+
+                        # A populated User Configuration block is the only per-user proof of
+                        # registration.
+                        if [ -n "$unique_id" ] || [ -n "$login_user_name" ]; then
+                            registered="true"
+                        fi
+
+                        # SSO Tokens trailer is plain text, not JSON:
+                        #   SSO Tokens:
+                        #   Received:
+                        #   2026-08-14T00:18:46Z
+                        #   Expiration:
+                        #   2026-08-28T00:18:45Z (Not Expired)
+                        if printf '%s\\n' "$token_section" | grep -q '^Received:'; then
+                            token_received=$(printf '%s\\n' "$token_section" \\
+                                | awk '/^Received:/{getline; gsub(/^[ \\t]+|[ \\t]+$/,""); print; exit}')
+                            token_expiration_raw=$(printf '%s\\n' "$token_section" \\
+                                | awk '/^Expiration:/{getline; gsub(/^[ \\t]+|[ \\t]+$/,""); print; exit}')
+                            token_expiration=$(printf '%s' "$token_expiration_raw" | sed 's/ *(.*$//')
+                            case "$token_expiration_raw" in
+                                *"Not Expired"*) token_expired="false" ;;
+                                *"Expired"*)     token_expired="true" ;;
+                            esac
+                            if [ -n "$token_received" ]; then
+                                has_tokens="true"
+                            fi
+                        fi
                     fi
-                    
-                    # Try to extract user principal name
-                    user_upn=$(echo "$user_sso" | grep '"userPrincipalName"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
+                fi
+
+                if [ "$registered" = "true" ]; then
+                    registered_count=$((registered_count + 1))
                 else
                     unregistered_count=$((unregistered_count + 1))
                 fi
-                
-                if [ "$first_user" = "true" ]; then
-                    first_user="false"
-                else
-                    users_json="$users_json,"
+                if [ "$has_tokens" = "true" ]; then
+                    token_count=$((token_count + 1))
                 fi
-                
+
+                [ "$first_user" = "true" ] && first_user="false" || users_json="$users_json,"
                 users_json="$users_json{"
-                users_json="$users_json\\"username\\": \\"$user\\","
-                users_json="$users_json\\"registered\\": $user_registered,"
-                users_json="$users_json\\"userPrincipalName\\": \\"$user_upn\\""
+                users_json="$users_json\\"username\\": \\"$(json_scrub "$user")\\","
+                users_json="$users_json\\"uid\\": $uid,"
+                users_json="$users_json\\"registered\\": $registered,"
+                users_json="$users_json\\"userPrincipalName\\": \\"$(json_scrub "$upn")\\","
+                users_json="$users_json\\"loginUserName\\": \\"$(json_scrub "$login_user_name")\\","
+                users_json="$users_json\\"uniqueIdentifier\\": \\"$(json_scrub "$unique_id")\\","
+                users_json="$users_json\\"state\\": \\"$(json_scrub "$user_state")\\","
+                users_json="$users_json\\"loginType\\": \\"$(json_scrub "$login_type")\\","
+                users_json="$users_json\\"lastLoginDate\\": \\"$(json_scrub "$last_login")\\","
+                users_json="$users_json\\"tokensPresent\\": $has_tokens,"
+                users_json="$users_json\\"tokenReceived\\": \\"$(json_scrub "$token_received")\\","
+                users_json="$users_json\\"tokenExpiration\\": \\"$(json_scrub "$token_expiration")\\","
+                users_json="$users_json\\"tokenExpired\\": $token_expired,"
+                users_json="$users_json\\"probeStatus\\": \\"$probe_status\\""
                 users_json="$users_json}"
             done
-            
             users_json="$users_json]"
-            
+
             echo "{"
             echo "  \\"supported\\": true,"
-            echo "  \\"deviceRegistered\\": true,"
+            echo "  \\"deviceRegistered\\": $device_registered,"
             echo "  \\"registeredUserCount\\": $registered_count,"
             echo "  \\"unregisteredUserCount\\": $unregistered_count,"
+            echo "  \\"tokenPresentCount\\": $token_count,"
+            echo "  \\"nonPlatformSSOAccounts\\": $non_psso_json,"
             echo "  \\"users\\": $users_json"
             echo "}"
         """
-        
+
         return try await executeWithFallback(
             osquery: nil,
             bash: bashScript

--- a/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
@@ -662,6 +662,12 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
                 echo "{"
                 echo "  \\"supported\\": false,"
                 echo "  \\"deviceRegistered\\": false,"
+                echo "  \\"provider\\": \\"\\","
+                echo "  \\"method\\": \\"\\","
+                echo "  \\"extensionIdentifier\\": \\"\\","
+                echo "  \\"organizationName\\": \\"\\","
+                echo "  \\"loginFrequency\\": 0,"
+                echo "  \\"offlineGracePeriod\\": \\"\\","
                 echo "  \\"registeredUserCount\\": 0,"
                 echo "  \\"unregisteredUserCount\\": 0,"
                 echo "  \\"tokenPresentCount\\": 0,"
@@ -729,6 +735,39 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             if printf '%s\\n' "$device_section" | grep -q '"registrationCompleted" *: *true'; then
                 device_registered="true"
             fi
+
+            extension_id=$(printf '%s\\n' "$device_section" | json_string extensionIdentifier)
+            org_name=$(printf '%s\\n' "$device_section" | json_string accountDisplayName)
+            offline_grace=$(printf '%s\\n' "$device_section" | json_string offlineGracePeriod)
+            login_freq=$(printf '%s\\n' "$device_section" | grep '"loginFrequency"' | head -1 | sed 's/[^0-9]//g')
+            [ -z "$login_freq" ] && login_freq=0
+
+            # Identify the IdP from the extension bundle id, falling back to the account
+            # display name. The extension id is the reliable signal.
+            provider=""
+            case "$extension_id" in
+                *microsoft*|*Microsoft*) provider="Microsoft Entra ID" ;;
+                *okta*|*Okta*)           provider="Okta" ;;
+                *jamf*|*Jamf*)           provider="Jamf Connect" ;;
+                *google*|*Google*)       provider="Google" ;;
+            esac
+            if [ -z "$provider" ]; then
+                case "$org_name" in
+                    *Entra*|*Microsoft*) provider="Microsoft Entra ID" ;;
+                    *Okta*)              provider="Okta" ;;
+                    *Jamf*)              provider="Jamf Connect" ;;
+                    *Google*)            provider="Google" ;;
+                esac
+            fi
+
+            # Device-wide authentication method from the configured login type.
+            device_login_type=$(printf '%s\\n' "$device_section" | json_string loginType)
+            method="Unknown"
+            case "$device_login_type" in
+                *SecureEnclaveKey*) method="Secure enclave key" ;;
+                *SmartCard*)        method="Smart card" ;;
+                *Password*)         method="Password" ;;
+            esac
 
             # Accounts the PSSO payload exempts by policy. Never probe these: they have no SSO
             # agent, so app-sso would hang against them.
@@ -893,6 +932,12 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             echo "{"
             echo "  \\"supported\\": true,"
             echo "  \\"deviceRegistered\\": $device_registered,"
+            echo "  \\"provider\\": \\"$(json_scrub "$provider")\\","
+            echo "  \\"method\\": \\"$(json_scrub "$method")\\","
+            echo "  \\"extensionIdentifier\\": \\"$(json_scrub "$extension_id")\\","
+            echo "  \\"organizationName\\": \\"$(json_scrub "$org_name")\\","
+            echo "  \\"loginFrequency\\": $login_freq,"
+            echo "  \\"offlineGracePeriod\\": \\"$(json_scrub "$offline_grace")\\","
             echo "  \\"registeredUserCount\\": $registered_count,"
             echo "  \\"unregisteredUserCount\\": $unregistered_count,"
             echo "  \\"tokenPresentCount\\": $token_count,"

--- a/Sources/DataCollection/Modules/SecurityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/SecurityModuleProcessor.swift
@@ -1145,7 +1145,57 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         let bashScript = """
             # Platform SSO status check (macOS 13+ Ventura and later)
             # Collects device-level config and per-user SSO registration
-            
+            set -m
+
+            # Run a command under a hard wall-clock limit, killing its whole process group on
+            # expiry. app-sso blocks forever against a user with no GUI session, and output is
+            # staged through a temp file so a surviving grandchild can never hold our stdout
+            # pipe open.
+            run_with_timeout() {
+                _limit=$1
+                shift
+                _out=$(mktemp /tmp/reportmate-psso.XXXXXX) || return 1
+                "$@" >"$_out" 2>/dev/null &
+                _pid=$!
+                _waited=0
+                while kill -0 "$_pid" 2>/dev/null; do
+                    if [ "$_waited" -ge "$_limit" ]; then
+                        kill -9 -"$_pid" 2>/dev/null
+                        kill -9 "$_pid" 2>/dev/null
+                        wait "$_pid" 2>/dev/null
+                        rm -f "$_out"
+                        return 124
+                    fi
+                    sleep 1
+                    _waited=$((_waited + 1))
+                done
+                wait "$_pid" 2>/dev/null
+                cat "$_out"
+                rm -f "$_out"
+                return 0
+            }
+
+            running_uid=$(id -u)
+
+            # Platform SSO state is per-user and only reachable inside that user's Aqua
+            # session, so a user with no GUI session must never be probed.
+            has_gui_session() {
+                if [ "$running_uid" = "$1" ]; then
+                    return 0
+                fi
+                launchctl print "gui/$1" >/dev/null 2>&1
+            }
+
+            appsso_for_user() {
+                if [ "$running_uid" = "0" ]; then
+                    run_with_timeout 20 launchctl asuser "$2" sudo -u "$1" /usr/bin/app-sso platform -s
+                elif [ "$running_uid" = "$2" ]; then
+                    run_with_timeout 20 /usr/bin/app-sso platform -s
+                else
+                    return 1
+                fi
+            }
+
             # Check macOS version (Platform SSO requires 13+)
             os_version=$(sw_vers -productVersion | cut -d. -f1)
             if [ "$os_version" -lt 13 ]; then
@@ -1163,7 +1213,7 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             fi
             
             # First get device-level SSO state (can run as root)
-            sso_state=$(app-sso platform -s 2>/dev/null || echo "")
+            sso_state=$(run_with_timeout 20 /usr/bin/app-sso platform -s)
             
             # Initialize device-level variables
             registered="false"
@@ -1234,10 +1284,21 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
                     if [ ! -d "$user_home" ] || [ "$user_home" = "/var/empty" ]; then
                         continue
                     fi
-                    
+
+                    # Accounts the payload exempts from Platform SSO have no SSO agent and
+                    # would hang the probe, so skip them outright.
+                    if echo ",$non_psso_accounts," | grep -qF ",$user,"; then
+                        continue
+                    fi
+
+                    user_uid=$(dscl . -read /Users/"$user" UniqueID 2>/dev/null | awk '{print $2}' || echo "")
+                    if [ -z "$user_uid" ] || ! has_gui_session "$user_uid"; then
+                        continue
+                    fi
+
                     # Get SSO state for this user
-                    user_sso=$(sudo -u "$user" app-sso platform -s 2>/dev/null || echo "")
-                    
+                    user_sso=$(appsso_for_user "$user" "$user_uid")
+
                     user_registered="false"
                     user_upn=""
                     user_email=""
@@ -1248,17 +1309,22 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
                     token_expiration=""
                     
                     if [ -n "$user_sso" ]; then
-                        # Check User Configuration section for this user's SSO data
-                        if echo "$user_sso" | grep -q "User Configuration:"; then
+                        # Scope extraction to the per-user block. The Device and Login
+                        # Configuration blocks print for every account regardless of that
+                        # account's registration, so matching against the whole output
+                        # attributes device-level values to unregistered users.
+                        user_section=$(echo "$user_sso" | awk '/^User Configuration:/{f=1;next} f&&/^SSO Tokens:/{f=0} f')
+
+                        if [ -n "$user_section" ]; then
                             # Extract UPN (prefer clean one without KERBEROS suffix)
-                            user_upn=$(echo "$user_sso" | grep '"upn"' | grep -v "KERBEROS" | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
+                            user_upn=$(echo "$user_section" | grep '"upn"' | grep -v "KERBEROS" | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
                             if [ -z "$user_upn" ]; then
-                                user_upn=$(echo "$user_sso" | grep '"upn"' | head -1 | sed 's/.*: *"\\([^@]*@[^@]*\\)@.*/\\1/' | sed 's/\\\\\\\\@/@/' || echo "")
+                                user_upn=$(echo "$user_section" | grep '"upn"' | head -1 | sed 's/.*: *"\\([^@]*@[^@]*\\)@.*/\\1/' | sed 's/\\\\\\\\@/@/' || echo "")
                             fi
-                            
+
                             # Extract loginUserName (may be masked)
-                            user_email=$(echo "$user_sso" | grep '"loginUserName"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                            
+                            user_email=$(echo "$user_section" | grep '"loginUserName"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
+
                             # Prefer UPN if email is masked
                             if [ -n "$user_upn" ]; then
                                 if [ -z "$user_email" ] || echo "$user_email" | grep -q '\\*\\*\\*'; then
@@ -1272,10 +1338,10 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
                             fi
                             
                             # Extract last login date
-                            user_last_login=$(echo "$user_sso" | grep '"lastLoginDate"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                            
+                            user_last_login=$(echo "$user_section" | grep '"lastLoginDate"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
+
                             # Extract user state
-                            user_state=$(echo "$user_sso" | grep '"state"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
+                            user_state=$(echo "$user_section" | grep '"state"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
                         fi
                         
                         # Check for SSO Tokens section (appears at end of output, not in JSON format)
@@ -1907,9 +1973,32 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         ConsoleFormatter.writeDebug("Microsoft Defender: mdatp CLI found, collecting health data")
         
         do {
-            // Get health status
-            let healthOutput = try await executeBashScript("/usr/local/bin/mdatp health --output json 2>/dev/null || echo '{}'")
-            
+            // Get health status. `mdatp health` can block indefinitely when the Defender
+            // daemon is wedged, which would stall the entire security collection - and with
+            // it the Platform SSO data reported below - so bound it and fall back to empty.
+            let healthOutput = try await executeBashScript("""
+                set -m
+                out=$(mktemp /tmp/reportmate-mdatp.XXXXXX) || { echo '{}'; exit 0; }
+                /usr/local/bin/mdatp health --output json >"$out" 2>/dev/null &
+                pid=$!
+                waited=0
+                while kill -0 "$pid" 2>/dev/null; do
+                    if [ "$waited" -ge 30 ]; then
+                        kill -9 -"$pid" 2>/dev/null
+                        kill -9 "$pid" 2>/dev/null
+                        wait "$pid" 2>/dev/null
+                        rm -f "$out"
+                        echo '{}'
+                        exit 0
+                    fi
+                    sleep 1
+                    waited=$((waited + 1))
+                done
+                wait "$pid" 2>/dev/null
+                if [ -s "$out" ]; then cat "$out"; else echo '{}'; fi
+                rm -f "$out"
+                """)
+
             guard let healthData = healthOutput.data(using: .utf8),
                   let healthJson = try? JSONSerialization.jsonObject(with: healthData) as? [String: Any] else {
                 ConsoleFormatter.writeDebug("Microsoft Defender: failed to parse health JSON")

--- a/Sources/DataCollection/Modules/SecurityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/SecurityModuleProcessor.swift
@@ -14,7 +14,7 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
     
     public override func collectData() async throws -> ModuleData {
         // Total collection steps for progress tracking
-        let totalSteps = 23
+        let totalSteps = 22
         
         // Collect security data sequentially with progress tracking
         ConsoleFormatter.writeQueryProgress(queryName: "sip_status", current: 1, total: totalSteps)
@@ -53,37 +53,37 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         ConsoleFormatter.writeQueryProgress(queryName: "activation_lock", current: 12, total: totalSteps)
         let activationLock = try await collectActivationLockStatus()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "platform_sso", current: 13, total: totalSteps)
-        let platformSSO = try await collectPlatformSSOStatus()
-        
-        ConsoleFormatter.writeQueryProgress(queryName: "filevault_users", current: 14, total: totalSteps)
+        // Platform SSO is an identity concern, not a security-posture one, and lives in the
+        // identity module (identity.platformSSO). It was collected here as well, which meant
+        // it also sat behind this module's slower probes.
+        ConsoleFormatter.writeQueryProgress(queryName: "filevault_users", current: 13, total: totalSteps)
         let fvUsers = try await collectFileVaultUsers()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "secure_token", current: 15, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "secure_token", current: 14, total: totalSteps)
         let secureToken = try await collectSecureTokenStatus()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "bootstrap_token", current: 16, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "bootstrap_token", current: 15, total: totalSteps)
         let bootstrapToken = try await collectBootstrapTokenStatus()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "authdb", current: 17, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "authdb", current: 16, total: totalSteps)
         let authdb = try await collectAuthDB()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "unpatched_cves", current: 18, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "unpatched_cves", current: 17, total: totalSteps)
         let unpatchedCVEs = try await collectSofaUnpatchedCVEs()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "security_release", current: 19, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "security_release", current: 18, total: totalSteps)
         let securityRelease = try await collectSofaSecurityReleaseInfo()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "remote_management", current: 20, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "remote_management", current: 19, total: totalSteps)
         let remoteMgmt = try await collectRemoteManagement()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "certificates", current: 21, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "certificates", current: 20, total: totalSteps)
         let certificates = try await collectCertificates()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "endpoint_security", current: 22, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "endpoint_security", current: 21, total: totalSteps)
         let endpointSecurity = try await collectEndpointSecurityExtensions()
         
-        ConsoleFormatter.writeQueryProgress(queryName: "edr_products", current: 23, total: totalSteps)
+        ConsoleFormatter.writeQueryProgress(queryName: "edr_products", current: 22, total: totalSteps)
         let edrProducts = try await collectEDRProducts()
         
         // Build security data dictionary
@@ -103,7 +103,6 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             "mrt": mrt,
             "secureEnclave": secureEnclave,
             "activationLock": activationLock,
-            "platformSSO": platformSSO,
             "authorizationDB": authdb,
             "unpatchedCVEs": unpatchedCVEs,
             "securityReleaseInfo": securityRelease,
@@ -1127,314 +1126,6 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             echo "  \\"email\\": \\"$fmm_email\\","
             echo "  \\"ownerDisplayName\\": \\"$fmm_owner\\","
             echo "  \\"personId\\": \\"$fmm_person_id\\""
-            echo "}"
-        """
-        
-        return try await executeWithFallback(
-            osquery: nil,
-            bash: bashScript
-        )
-    }
-    
-    // MARK: - Platform Single Sign-On Status (bash: app-sso)
-    
-    private func collectPlatformSSOStatus() async throws -> [String: Any] {
-        // Platform SSO is macOS 13+ feature for enterprise single sign-on
-        // Uses the app-sso command-line tool with -s flag to get state (JSON-like format)
-        // Collects comprehensive device config + per-user SSO data
-        let bashScript = """
-            # Platform SSO status check (macOS 13+ Ventura and later)
-            # Collects device-level config and per-user SSO registration
-            set -m
-
-            # Run a command under a hard wall-clock limit, killing its whole process group on
-            # expiry. app-sso blocks forever against a user with no GUI session, and output is
-            # staged through a temp file so a surviving grandchild can never hold our stdout
-            # pipe open.
-            run_with_timeout() {
-                _limit=$1
-                shift
-                _out=$(mktemp /tmp/reportmate-psso.XXXXXX) || return 1
-                "$@" >"$_out" 2>/dev/null &
-                _pid=$!
-                _waited=0
-                while kill -0 "$_pid" 2>/dev/null; do
-                    if [ "$_waited" -ge "$_limit" ]; then
-                        kill -9 -"$_pid" 2>/dev/null
-                        kill -9 "$_pid" 2>/dev/null
-                        wait "$_pid" 2>/dev/null
-                        rm -f "$_out"
-                        return 124
-                    fi
-                    sleep 1
-                    _waited=$((_waited + 1))
-                done
-                wait "$_pid" 2>/dev/null
-                cat "$_out"
-                rm -f "$_out"
-                return 0
-            }
-
-            running_uid=$(id -u)
-
-            # Platform SSO state is per-user and only reachable inside that user's Aqua
-            # session, so a user with no GUI session must never be probed.
-            has_gui_session() {
-                if [ "$running_uid" = "$1" ]; then
-                    return 0
-                fi
-                launchctl print "gui/$1" >/dev/null 2>&1
-            }
-
-            appsso_for_user() {
-                if [ "$running_uid" = "0" ]; then
-                    run_with_timeout 20 launchctl asuser "$2" sudo -u "$1" /usr/bin/app-sso platform -s
-                elif [ "$running_uid" = "$2" ]; then
-                    run_with_timeout 20 /usr/bin/app-sso platform -s
-                else
-                    return 1
-                fi
-            }
-
-            # Check macOS version (Platform SSO requires 13+)
-            os_version=$(sw_vers -productVersion | cut -d. -f1)
-            if [ "$os_version" -lt 13 ]; then
-                echo "{"
-                echo "  \\"supported\\": false,"
-                echo "  \\"registered\\": false,"
-                echo "  \\"provider\\": \\"\\"," 
-                echo "  \\"method\\": \\"Not supported (macOS 13+ required)\\","
-                echo "  \\"extensionIdentifier\\": \\"\\"," 
-                echo "  \\"loginFrequency\\": 0,"
-                echo "  \\"offlineGracePeriod\\": \\"\\"," 
-                echo "  \\"users\\": []"
-                echo "}"
-                exit 0
-            fi
-            
-            # First get device-level SSO state (can run as root)
-            sso_state=$(run_with_timeout 20 /usr/bin/app-sso platform -s)
-            
-            # Initialize device-level variables
-            registered="false"
-            sso_provider=""
-            method="Unknown"
-            extension_id=""
-            org_name=""
-            login_freq="0"
-            offline_grace=""
-            non_psso_accounts=""
-            
-            if [ -n "$sso_state" ]; then
-                # Check registration status
-                if echo "$sso_state" | grep -q '"registrationCompleted" *: *true'; then
-                    registered="true"
-                fi
-                
-                # Extract SSO extension identifier
-                extension_id=$(echo "$sso_state" | grep '"extensionIdentifier"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                
-                # Extract organization/account display name (first one is org name)
-                org_name=$(echo "$sso_state" | grep '"accountDisplayName"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                
-                # Extract provider from accountDisplayName (find the IdP entry)
-                provider_val=$(echo "$sso_state" | grep '"accountDisplayName"' | grep -i "Entra\\|Okta\\|Google\\|Jamf\\|Microsoft" | head -1 || echo "")
-                if echo "$provider_val" | grep -qi "Microsoft\\|Entra"; then
-                    sso_provider="Microsoft Entra ID"
-                elif echo "$provider_val" | grep -qi "Okta"; then
-                    sso_provider="Okta"
-                elif echo "$provider_val" | grep -qi "Google"; then
-                    sso_provider="Google"
-                elif echo "$provider_val" | grep -qi "Jamf"; then
-                    sso_provider="Jamf Connect"
-                fi
-                
-                # Extract login type / method
-                login_type=$(echo "$sso_state" | grep '"loginType"' | head -1 || echo "")
-                if echo "$login_type" | grep -qi "SecureEnclaveKey"; then
-                    method="Secure enclave key"
-                elif echo "$login_type" | grep -qi "Password"; then
-                    method="Password"
-                elif echo "$login_type" | grep -qi "SmartCard"; then
-                    method="Smart Card"
-                fi
-                
-                # Extract login frequency (seconds)
-                login_freq=$(echo "$sso_state" | grep '"loginFrequency"' | head -1 | sed 's/[^0-9]//g' || echo "0")
-                
-                # Extract offline grace period
-                offline_grace=$(echo "$sso_state" | grep '"offlineGracePeriod"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                
-                # Extract non-Platform SSO accounts (local accounts) - array format
-                non_psso_accounts=$(echo "$sso_state" | sed -n '/"nonPlatformSSOAccounts"/,/\\]/p' | grep -v 'nonPlatformSSOAccounts' | grep '"' | sed 's/.*"\\([^"]*\\)".*/\\1/' | tr '\\n' ',' | sed 's/,$//' || echo "")
-            fi
-            
-            # Now collect per-user SSO data (only if registered)
-            users_json="[]"
-            if [ "$registered" = "true" ]; then
-                # Get all human users on the system
-                all_users=$(dscl . -list /Users | grep -v "^_" | grep -v "daemon\\|nobody\\|root\\|Guest" || echo "")
-                
-                users_json="["
-                first_user="true"
-                
-                for user in $all_users; do
-                    # Get user's home directory to check if real user
-                    user_home=$(dscl . -read /Users/"$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}' || echo "")
-                    if [ ! -d "$user_home" ] || [ "$user_home" = "/var/empty" ]; then
-                        continue
-                    fi
-
-                    # Accounts the payload exempts from Platform SSO have no SSO agent and
-                    # would hang the probe, so skip them outright.
-                    if echo ",$non_psso_accounts," | grep -qF ",$user,"; then
-                        continue
-                    fi
-
-                    user_uid=$(dscl . -read /Users/"$user" UniqueID 2>/dev/null | awk '{print $2}' || echo "")
-                    if [ -z "$user_uid" ] || ! has_gui_session "$user_uid"; then
-                        continue
-                    fi
-
-                    # Get SSO state for this user
-                    user_sso=$(appsso_for_user "$user" "$user_uid")
-
-                    user_registered="false"
-                    user_upn=""
-                    user_email=""
-                    user_tokens="false"
-                    user_last_login=""
-                    user_state=""
-                    token_received=""
-                    token_expiration=""
-                    
-                    if [ -n "$user_sso" ]; then
-                        # Scope extraction to the per-user block. The Device and Login
-                        # Configuration blocks print for every account regardless of that
-                        # account's registration, so matching against the whole output
-                        # attributes device-level values to unregistered users.
-                        user_section=$(echo "$user_sso" | awk '/^User Configuration:/{f=1;next} f&&/^SSO Tokens:/{f=0} f')
-
-                        if [ -n "$user_section" ]; then
-                            # Extract UPN (prefer clean one without KERBEROS suffix)
-                            user_upn=$(echo "$user_section" | grep '"upn"' | grep -v "KERBEROS" | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                            if [ -z "$user_upn" ]; then
-                                user_upn=$(echo "$user_section" | grep '"upn"' | head -1 | sed 's/.*: *"\\([^@]*@[^@]*\\)@.*/\\1/' | sed 's/\\\\\\\\@/@/' || echo "")
-                            fi
-
-                            # Extract loginUserName (may be masked)
-                            user_email=$(echo "$user_section" | grep '"loginUserName"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-
-                            # Prefer UPN if email is masked
-                            if [ -n "$user_upn" ]; then
-                                if [ -z "$user_email" ] || echo "$user_email" | grep -q '\\*\\*\\*'; then
-                                    user_email="$user_upn"
-                                fi
-                            fi
-                            
-                            # If we have UPN or email, user is registered
-                            if [ -n "$user_upn" ] || [ -n "$user_email" ]; then
-                                user_registered="true"
-                            fi
-                            
-                            # Extract last login date
-                            user_last_login=$(echo "$user_section" | grep '"lastLoginDate"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-
-                            # Extract user state
-                            user_state=$(echo "$user_section" | grep '"state"' | head -1 | sed 's/.*: *"\\([^"]*\\)".*/\\1/' || echo "")
-                        fi
-                        
-                        # Check for SSO Tokens section (appears at end of output, not in JSON format)
-                        # Format is:
-                        # SSO Tokens:
-                        # Received:
-                        # 2026-01-16T17:48:17Z
-                        # Expiration:
-                        # 2026-01-30T17:48:16Z (Not Expired)
-                        if echo "$user_sso" | grep -q "^SSO Tokens:"; then
-                            # Extract the token received timestamp (line after "Received:")
-                            token_received=$(echo "$user_sso" | awk '/^Received:/{getline; print; exit}' | tr -d ' ')
-                            # Extract the token expiration (line after "Expiration:")
-                            token_expiration=$(echo "$user_sso" | awk '/^Expiration:/{getline; print; exit}' | sed 's/ *(.*$//' | tr -d ' ')
-                            
-                            # If we have a received timestamp, tokens are present
-                            if [ -n "$token_received" ] && [ "$token_received" != "" ]; then
-                                user_tokens="true"
-                            fi
-                        fi
-                    fi
-                    
-                    # Add user to JSON array if they have any SSO data
-                    if [ "$user_registered" = "true" ] || [ -n "$user_upn" ] || [ -n "$user_email" ]; then
-                        if [ "$first_user" = "true" ]; then
-                            first_user="false"
-                        else
-                            users_json="$users_json,"
-                        fi
-                        
-                        # Convert boolean to integer for tokensPresent (1 or 0)
-                        if [ "$user_tokens" = "true" ]; then
-                            tokens_val=1
-                        else
-                            tokens_val=0
-                        fi
-                        
-                        # Convert registered boolean to integer
-                        if [ "$user_registered" = "true" ]; then
-                            registered_val=1
-                        else
-                            registered_val=0
-                        fi
-                        
-                        users_json="$users_json{"
-                        users_json="$users_json\\"username\\": \\"$user\\","
-                        users_json="$users_json\\"registered\\": $registered_val,"
-                        users_json="$users_json\\"upn\\": \\"$user_upn\\","
-                        users_json="$users_json\\"loginEmail\\": \\"$user_email\\","
-                        users_json="$users_json\\"lastLogin\\": \\"$user_last_login\\","
-                        users_json="$users_json\\"state\\": \\"$user_state\\","
-                        users_json="$users_json\\"tokensPresent\\": $tokens_val,"
-                        users_json="$users_json\\"tokenReceived\\": \\"$token_received\\","
-                        users_json="$users_json\\"tokenExpiration\\": \\"$token_expiration\\""
-                        users_json="$users_json}"
-                    fi
-                done
-                users_json="$users_json]"
-            fi
-            
-            # Fallback: Check for SSO provider via profile if not found
-            if [ "$sso_provider" = "" ] && [ "$registered" = "false" ]; then
-                azure_check=$(profiles show -type configuration 2>/dev/null | grep -i "microsoft\\|azure\\|entra" || echo "")
-                okta_check=$(profiles show -type configuration 2>/dev/null | grep -i "okta" || echo "")
-                jamf_check=$(profiles show -type configuration 2>/dev/null | grep -i "jamf connect" || echo "")
-                
-                if [ -n "$azure_check" ]; then
-                    sso_provider="Microsoft Entra ID"
-                elif [ -n "$okta_check" ]; then
-                    sso_provider="Okta"
-                elif [ -n "$jamf_check" ]; then
-                    sso_provider="Jamf Connect"
-                fi
-            fi
-            
-            # Convert device-level registered to integer
-            if [ "$registered" = "true" ]; then
-                registered_int=1
-            else
-                registered_int=0
-            fi
-            
-            echo "{"
-            echo "  \\"supported\\": 1,"
-            echo "  \\"registered\\": $registered_int,"
-            echo "  \\"provider\\": \\"$sso_provider\\","
-            echo "  \\"method\\": \\"$method\\","
-            echo "  \\"extensionIdentifier\\": \\"$extension_id\\","
-            echo "  \\"organizationName\\": \\"$org_name\\","
-            echo "  \\"loginFrequency\\": $login_freq,"
-            echo "  \\"offlineGracePeriod\\": \\"$offline_grace\\","
-            echo "  \\"nonPlatformSSOAccounts\\": \\"$non_psso_accounts\\","
-            echo "  \\"users\\": $users_json"
             echo "}"
         """
         

--- a/Sources/Models/Modules/IdentityModels.swift
+++ b/Sources/Models/Modules/IdentityModels.swift
@@ -335,39 +335,86 @@ public struct PlatformSSOUsersInfo: Codable, Sendable {
     public let deviceRegistered: Bool
     public let registeredUserCount: Int
     public let unregisteredUserCount: Int
+    public let tokenPresentCount: Int
+    /// Accounts the Platform SSO payload exempts from registration (`nonPlatformSSOAccounts`)
+    public let nonPlatformSSOAccounts: [String]
     public let users: [PlatformSSOUser]
-    
+
     public init(
         supported: Bool = false,
         deviceRegistered: Bool = false,
         registeredUserCount: Int = 0,
         unregisteredUserCount: Int = 0,
+        tokenPresentCount: Int = 0,
+        nonPlatformSSOAccounts: [String] = [],
         users: [PlatformSSOUser] = []
     ) {
         self.supported = supported
         self.deviceRegistered = deviceRegistered
         self.registeredUserCount = registeredUserCount
         self.unregisteredUserCount = unregisteredUserCount
+        self.tokenPresentCount = tokenPresentCount
+        self.nonPlatformSSOAccounts = nonPlatformSSOAccounts
         self.users = users
     }
 }
 
-/// Individual user's Platform SSO registration status
+/// Individual user's Platform SSO registration and token state
 public struct PlatformSSOUser: Codable, Sendable, Identifiable {
     public var id: String { username }
-    
+
     public let username: String
+    public let uid: Int?
     public let registered: Bool
+    /// Resolved from the Kerberos realm entry, e.g. `user@EXAMPLE.CA`
     public let userPrincipalName: String?
-    
+    /// Name shown by the SSO extension, masked by macOS as `u***r@example.ca`
+    public let loginUserName: String?
+    public let uniqueIdentifier: String?
+    /// Raw `POUserState*` value, e.g. `POUserStateNormal (0)`
+    public let state: String?
+    /// Raw `POLoginType*` value, e.g. `POLoginTypeUserSecureEnclaveKey (2)`
+    public let loginType: String?
+    public let lastLoginDate: String?
+    public let tokensPresent: Bool
+    public let tokenReceived: String?
+    public let tokenExpiration: String?
+    /// nil when no token is present, so "no token" stays distinct from "token valid"
+    public let tokenExpired: Bool?
+    /// Why the user was or was not probed: `ok`, `excluded`, `no-session`,
+    /// `device-not-registered`, `probe-failed`
+    public let probeStatus: String?
+
     public init(
         username: String,
+        uid: Int? = nil,
         registered: Bool = false,
-        userPrincipalName: String? = nil
+        userPrincipalName: String? = nil,
+        loginUserName: String? = nil,
+        uniqueIdentifier: String? = nil,
+        state: String? = nil,
+        loginType: String? = nil,
+        lastLoginDate: String? = nil,
+        tokensPresent: Bool = false,
+        tokenReceived: String? = nil,
+        tokenExpiration: String? = nil,
+        tokenExpired: Bool? = nil,
+        probeStatus: String? = nil
     ) {
         self.username = username
+        self.uid = uid
         self.registered = registered
         self.userPrincipalName = userPrincipalName
+        self.loginUserName = loginUserName
+        self.uniqueIdentifier = uniqueIdentifier
+        self.state = state
+        self.loginType = loginType
+        self.lastLoginDate = lastLoginDate
+        self.tokensPresent = tokensPresent
+        self.tokenReceived = tokenReceived
+        self.tokenExpiration = tokenExpiration
+        self.tokenExpired = tokenExpired
+        self.probeStatus = probeStatus
     }
 }
 


### PR DESCRIPTION
`managedreportsrunner --run-module identity` reported every account as Platform SSO registered with an empty UPN and no token state at all. Three defects in the collector, plus a structural one.

## Collection

**Per-user registration was read from a device-level key.** The module grepped the whole `app-sso platform -s` output for `registrationCompleted: true`. That key lives in the `Device Configuration` block, which prints identically for every account — including accounts the payload itself lists in `nonPlatformSSOAccounts`. On the test device `admin` and `macadmins` both came back registered. Per-user truth is a populated `User Configuration` block, so parse by section instead.

**`userPrincipalName` does not exist in the output.** The real UPN lives in the `kerberosStatus` realm entries. The on-prem entry is clean (`user@EXAMPLE.CA`); the cloud entry escapes the local part and appends the Kerberos realm, so it is unwrapped as a fallback. `loginUserName` is reported separately — macOS masks it as `u***r@example.ca`, so it proves registration but is not an identity.

**The model had no token fields.** `PlatformSSOUser` carried only username/registered/userPrincipalName, so token state could never be anything but missing regardless of what was collected. It now carries `tokensPresent`, `tokenReceived`, `tokenExpiration`, `tokenExpired`, plus `state`, `loginType`, `lastLoginDate`, `uniqueIdentifier` and `uid`, parsed from the plain-text `SSO Tokens` trailer and the user block.

## Hangs

Platform SSO state is only reachable inside a user's Aqua session. Probing a user with no GUI session blocks forever — it does not error out. That is why the module took three minutes on a three-account Mac. Every account is now gated on an active `gui/<uid>` launchd domain, probes run through `launchctl asuser` when collecting as root, and every invocation carries a hard timeout that kills the process group. A `probeStatus` field records why an account was or was not probed (`ok`, `excluded`, `no-session`, `device-not-registered`, `probe-failed`).

`mdatp health` is bounded for the same reason. It hangs when the Defender daemon wedges; two runs on the test device had been stuck on it for 30 minutes and almost six hours respectively.

## Platform SSO moves to the identity module

It was being collected twice — once in `identity`, once in `security` — by two separate copies of the same fragile parsing. Platform SSO is an identity concern, so the security module's copy is removed.

Everything device-level that copy carried and identity lacked moves across: `provider`, `method`, `extensionIdentifier`, `organizationName`, `loginFrequency`, `offlineGracePeriod`. Provider is now derived from the extension bundle id rather than string-matching the account display name. Nothing is lost.

The payload key stays `identity.platformSSOUsers` — the fleet API, the v1 identity route and the fleet identity page already read it, and `IdentityTab` uses its presence as a macOS-detection signal.

Collecting it in `security` also meant it sat behind that module's slower probes, including the wedged `mdatp` call — so the security module's Platform SSO data never shipped at all.

Web-side companion: reportmate/reportmate-app-web#39, which repoints the two device-detail consumers of `security.platformSSO` and fixes a separate `users[0]` bug that rendered the token as `Missing` independently of anything here.

## Verification

Identity module, rebuilt binary, run as root on a device with Platform SSO registered:

```
provider=Microsoft Entra ID  method=Secure enclave key
extensionIdentifier=com.microsoft.CompanyPortalMac.ssoextension
organizationName=<tenant account display name>  loginFrequency=64800
deviceRegistered=1  registeredUserCount=1  unregisteredUserCount=2  tokenPresentCount=1
nonPlatformSSOAccounts=[<local-admin>]

<local-admin>     registered=0  probeStatus=excluded
<no-gui-account>  registered=0  probeStatus=no-session
<console-user>    registered=1  probeStatus=ok
                  userPrincipalName=user@EXAMPLE.CA
                  tokensPresent=1  tokenExpiration=<iso-8601>  tokenExpired=0
```

Collection time for the Platform SSO step dropped from ~3 minutes to ~8 seconds.

## Known gap not addressed here

`BashService.execute` has no timeout at all: it calls `readDataToEndOfFile()` and waits forever. The two bounded commands in this PR are the demonstrated hangs, but any external command a module shells out to can stall a whole collection the same way. A general timeout on `BashService.execute` is the class fix and is worth doing separately.

