### PR TITLE
Enable LaunchDaemons before bootstrapping them in postinstall

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1290,13 +1290,31 @@ done
 for daemon in ${DAEMONS}; do
     source_path="${APP_ROOT}/Library/LaunchDaemons/${daemon}"
     dest_path="${LD_ROOT}/${daemon}"
-    
+    label="${daemon%.plist}"
+
     if [ -e "${source_path}" ]; then
         log_message "Installing: ${daemon}"
         cp "${source_path}" "${dest_path}"
         chmod 644 "${dest_path}"
         chown root:wheel "${dest_path}"
-        /bin/launchctl bootstrap system "${dest_path}"
+
+        # A `launchctl disable` is recorded in launchd's own override database
+        # (/var/db/com.apple.xpc.launchd/disabled.plist), keyed by label. That
+        # record is independent of the plist file, so removing and reinstalling
+        # the plist does not clear it, and bootstrap then fails with EIO for the
+        # life of the machine. Anyone who ever disabled a daemon to chase a
+        # performance problem would silently never get it back. Clear the
+        # override before bootstrapping.
+        /bin/launchctl enable "system/${label}" 2>/dev/null
+
+        if /bin/launchctl bootstrap system "${dest_path}" 2>/dev/null; then
+            log_message "Loaded: ${label}"
+        else
+            # Do not fail the install over one daemon, but never swallow it
+            # either - a daemon that silently fails to load is a module that
+            # silently stops being collected.
+            log_message "WARNING: failed to load ${label} - collection scheduled by this daemon will not run"
+        fi
     fi
 done
 


### PR DESCRIPTION
Closes #22

`launchctl disable` records its decision in launchd's override database at `/var/db/com.apple.xpc.launchd/disabled.plist`, keyed by service label and entirely independent of the plist file. The postinstall boots out the old daemon, removes the plist, copies the new one and calls `bootstrap` — none of which touches that database. So a daemon disabled once stays disabled through every later install, and `bootstrap` fails with `EIO` forever. The exit status was discarded, so the install still reported success.

What that looks like in practice is not an obviously broken daemon. It is a module that quietly stops being collected while the rest of the device keeps reporting normally, so it reads as a data bug — and it survives reinstalling the package, which is the first thing anyone would try.

This adds `launchctl enable system/<label>` before `bootstrap`, and logs the bootstrap result instead of dropping it.

## Verification

The old sequence against a disabled daemon, which is exactly what the postinstall does:

```
sudo launchctl disable system/com.github.reportmate.fourhourly
sudo launchctl bootout system /Library/LaunchDaemons/com.github.reportmate.fourhourly.plist
sudo launchctl bootstrap system /Library/LaunchDaemons/com.github.reportmate.fourhourly.plist
Bootstrap failed: 5: Input/output error
```

The new sequence against the same disabled daemon loads it:

```
sudo launchctl enable system/com.github.reportmate.fourhourly
sudo launchctl bootstrap system /Library/LaunchDaemons/com.github.reportmate.fourhourly.plist
```

`launchctl list` then shows the daemon loaded. The generated postinstall passes `zsh -n`.

## Note for existing machines

The fix only takes effect on the next install. Any machine that currently carries a disabled override stays broken until it receives a build with this change. `sudo launchctl print-disabled system | grep reportmate` reports which daemons are affected on a given machine.