### PR TITLE
Bound every bash command with a timeout and drain its pipes concurrently

### DIFF
--- a/Sources/Core/Services/BashService.swift
+++ b/Sources/Core/Services/BashService.swift
@@ -3,44 +3,40 @@ import Foundation
 /// Bash command execution service for fallback data collection
 public class BashService {
     
-    /// Execute a bash command and return output
-    public static func execute(_ command: String) async throws -> String {
-        return try await withCheckedThrowingContinuation { continuation in
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/bin/bash")
-            task.arguments = ["-c", command]
-            
-            let outputPipe = Pipe()
-            let errorPipe = Pipe()
-            task.standardOutput = outputPipe
-            task.standardError = errorPipe
-            
-            do {
-                try task.run()
-                
-                let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-                let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-                
-                task.waitUntilExit()
-                
-                if task.terminationStatus != 0 {
-                    let errorMessage = String(data: errorData, encoding: .utf8) ?? "Unknown error"
-                    continuation.resume(throwing: BashError.executionFailed(command, errorMessage))
-                    return
-                }
-                
-                let output = String(data: outputData, encoding: .utf8) ?? ""
-                continuation.resume(returning: output)
-                
-            } catch {
-                continuation.resume(throwing: BashError.processLaunchFailed(error))
-            }
+    /// Execute a bash command and return its standard output.
+    ///
+    /// Every command runs under a hard time budget. Without one, a single wedged external tool
+    /// stalls the whole collection silently and indefinitely: the module never reports, the
+    /// payload never ships, and the device simply goes quiet while the other daemons keep
+    /// running normally. That is far harder to spot than a crash. Observed in the wild with
+    /// `mdatp health` against a hung Defender daemon, which held two collection runs for
+    /// thirty minutes and nearly six hours respectively.
+    ///
+    /// - Parameter timeout: seconds before the command is terminated. Raise it for commands
+    ///   that are legitimately slow rather than removing the bound.
+    public static func execute(
+        _ command: String,
+        timeout: TimeInterval = ProcessRunner.defaultTimeout
+    ) async throws -> String {
+        let result = try await ProcessRunner.bash(command, timeout: timeout)
+
+        if result.timedOut {
+            throw BashError.timedOut(command, timeout)
         }
+
+        if result.exitCode != 0 {
+            let message = result.standardError.isEmpty ? "Unknown error" : result.standardError
+            throw BashError.executionFailed(command, message)
+        }
+
+        return result.standardOutput
     }
-    
+
     /// Execute system_profiler command for hardware information
     public static func executeSystemProfiler(_ dataType: String) async throws -> [String: Any] {
-        let output = try await execute("system_profiler \(dataType) -json")
+        // system_profiler is legitimately slow on large data types, so it gets a wider budget
+        // than the default - but still a bounded one.
+        let output = try await execute("system_profiler \(dataType) -json", timeout: 300)
         
         guard let jsonData = output.data(using: .utf8),
               let jsonObject = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
@@ -55,7 +51,8 @@ public enum BashError: Error, LocalizedError {
     case executionFailed(String, String)
     case processLaunchFailed(Error)
     case invalidOutput(String)
-    
+    case timedOut(String, TimeInterval)
+
     public var errorDescription: String? {
         switch self {
         case .executionFailed(let command, let error):
@@ -64,6 +61,8 @@ public enum BashError: Error, LocalizedError {
             return "Failed to launch bash process: \(error.localizedDescription)"
         case .invalidOutput(let message):
             return "Invalid bash output: \(message)"
+        case .timedOut(let command, let seconds):
+            return "Bash command exceeded its \(Int(seconds))s budget and was terminated: '\(command)'"
         }
     }
 }

--- a/Sources/Core/Services/ProcessRunner.swift
+++ b/Sources/Core/Services/ProcessRunner.swift
@@ -1,0 +1,264 @@
+import Foundation
+
+/// Result of a bounded external process run.
+public struct ProcessRunResult: Sendable {
+    public let standardOutput: String
+    public let standardError: String
+    public let exitCode: Int32
+    /// True when the process was killed because it exceeded its time budget.
+    public let timedOut: Bool
+}
+
+/// Runs external processes under a hard time budget.
+///
+/// Two properties matter, and the obvious implementation has neither:
+///
+/// 1. **Output is drained concurrently.** Reading stdout to EOF and only then reading stderr
+///    deadlocks whenever a command writes more than a pipe buffer (64 KB) to stderr: the child
+///    blocks writing stderr, the parent blocks reading stdout, and neither moves. That is a hang
+///    with no misbehaving command involved at all.
+///
+/// 2. **The timeout does not depend on EOF.** A command launched as `/bin/bash -c "..."` passes
+///    its inherited pipe to its own children, so killing bash alone does not close the write end
+///    — a wedged grandchild keeps it open and a blocking read waits forever. This drains through
+///    readability handlers and resolves the timeout independently, so a surviving grandchild can
+///    delay cleanup but can never stall collection.
+///
+/// Best-effort teardown then walks the process tree, because killing only the direct child
+/// leaves the grandchild that actually wedged still running.
+public enum ProcessRunner {
+
+    /// Default budget for a single external command. Individual collectors may pass more when a
+    /// command is legitimately slow; nothing should run unbounded.
+    public static let defaultTimeout: TimeInterval = 180
+
+    /// Grace period between SIGTERM and SIGKILL, matching the osquery runner.
+    private static let terminationGracePeriod: TimeInterval = 2
+
+    public static func run(
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval = defaultTimeout,
+        label: String? = nil
+    ) async throws -> ProcessRunResult {
+        let description = label ?? ([executable] + arguments).joined(separator: " ")
+        let box = ProcessBox()
+
+        return try await withThrowingTaskGroup(of: RunOutcome.self) { group in
+            group.addTask {
+                let result = try await runToCompletion(
+                    executable: executable,
+                    arguments: arguments,
+                    box: box
+                )
+                return .completed(result)
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                return .timedOut
+            }
+
+            defer { group.cancelAll() }
+
+            while let outcome = try await group.next() {
+                switch outcome {
+                case .completed(let result):
+                    return result
+
+                case .timedOut:
+                    ConsoleFormatter.writeDebug(
+                        "Command exceeded its \(Int(timeout))s budget, terminating: \(description)"
+                    )
+                    box.terminate()
+                    try? await Task.sleep(nanoseconds: UInt64(terminationGracePeriod * 1_000_000_000))
+                    box.forceKillTree()
+
+                    // Report rather than throw. A timed-out collector should degrade to an empty
+                    // result like any other failure, not abort the module around it.
+                    return ProcessRunResult(
+                        standardOutput: box.drainedOutput(),
+                        standardError: box.drainedError(),
+                        exitCode: -1,
+                        timedOut: true
+                    )
+                }
+            }
+
+            return ProcessRunResult(standardOutput: "", standardError: "", exitCode: -1, timedOut: false)
+        }
+    }
+
+    /// Convenience for the overwhelmingly common `/bin/bash -c` case.
+    public static func bash(
+        _ command: String,
+        timeout: TimeInterval = defaultTimeout
+    ) async throws -> ProcessRunResult {
+        try await run(
+            executable: "/bin/bash",
+            arguments: ["-c", command],
+            timeout: timeout,
+            label: command
+        )
+    }
+
+    private enum RunOutcome {
+        case completed(ProcessRunResult)
+        case timedOut
+    }
+
+    private static func runToCompletion(
+        executable: String,
+        arguments: [String],
+        box: ProcessBox
+    ) async throws -> ProcessRunResult {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: executable)
+            task.arguments = arguments
+
+            let outputPipe = Pipe()
+            let errorPipe = Pipe()
+            task.standardOutput = outputPipe
+            task.standardError = errorPipe
+
+            // Drain both pipes as data arrives. Nothing here blocks, so neither stream can
+            // back-pressure the other into a deadlock.
+            outputPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if !data.isEmpty { box.appendOutput(data) }
+            }
+            errorPipe.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if !data.isEmpty { box.appendError(data) }
+            }
+
+            task.terminationHandler = { finished in
+                // Collect whatever is still buffered before tearing the handlers down.
+                let remainingOut = outputPipe.fileHandleForReading.availableData
+                if !remainingOut.isEmpty { box.appendOutput(remainingOut) }
+                let remainingErr = errorPipe.fileHandleForReading.availableData
+                if !remainingErr.isEmpty { box.appendError(remainingErr) }
+
+                outputPipe.fileHandleForReading.readabilityHandler = nil
+                errorPipe.fileHandleForReading.readabilityHandler = nil
+
+                guard box.claimCompletion() else { return }
+                continuation.resume(returning: ProcessRunResult(
+                    standardOutput: box.drainedOutput(),
+                    standardError: box.drainedError(),
+                    exitCode: finished.terminationStatus,
+                    timedOut: false
+                ))
+            }
+
+            do {
+                try task.run()
+                box.attach(task)
+            } catch {
+                outputPipe.fileHandleForReading.readabilityHandler = nil
+                errorPipe.fileHandleForReading.readabilityHandler = nil
+                guard box.claimCompletion() else { return }
+                continuation.resume(throwing: BashError.processLaunchFailed(error))
+            }
+        }
+    }
+}
+
+/// Shared handle to a running Process plus its accumulated output, so the timeout path can kill
+/// it and read what it managed to produce from outside the task that launched it. Process is not
+/// Sendable across concurrency boundaries, hence the lock-guarded wrapper.
+final class ProcessBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var outputData = Data()
+    private var errorData = Data()
+    private var completionClaimed = false
+
+    func attach(_ process: Process) {
+        lock.lock(); defer { lock.unlock() }
+        self.process = process
+    }
+
+    func appendOutput(_ data: Data) {
+        lock.lock(); defer { lock.unlock() }
+        outputData.append(data)
+    }
+
+    func appendError(_ data: Data) {
+        lock.lock(); defer { lock.unlock() }
+        errorData.append(data)
+    }
+
+    func drainedOutput() -> String {
+        lock.lock(); defer { lock.unlock() }
+        return String(data: outputData, encoding: .utf8) ?? ""
+    }
+
+    func drainedError() -> String {
+        lock.lock(); defer { lock.unlock() }
+        return String(data: errorData, encoding: .utf8) ?? ""
+    }
+
+    /// Ensures the continuation is resumed exactly once across the completion and timeout paths.
+    func claimCompletion() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if completionClaimed { return false }
+        completionClaimed = true
+        return true
+    }
+
+    func terminate() {
+        lock.lock(); defer { lock.unlock() }
+        guard let process = process, process.isRunning else { return }
+        process.terminate()
+    }
+
+    /// SIGKILL the process and every descendant. Killing only the direct child leaves the
+    /// grandchild that actually wedged holding the inherited pipe.
+    func forceKillTree() {
+        lock.lock()
+        let pid = (process?.isRunning == true) ? process?.processIdentifier : nil
+        lock.unlock()
+        guard let pid = pid else { return }
+
+        for descendant in Self.descendants(of: pid).reversed() {
+            kill(descendant, SIGKILL)
+        }
+        kill(pid, SIGKILL)
+    }
+
+    /// Breadth-first walk of the process tree via pgrep, deepest last.
+    private static func descendants(of pid: pid_t, depth: Int = 0) -> [pid_t] {
+        guard depth < 8 else { return [] }
+        let children = pgrepChildren(of: pid)
+        var all: [pid_t] = []
+        for child in children {
+            all.append(child)
+            all.append(contentsOf: descendants(of: child, depth: depth + 1))
+        }
+        return all
+    }
+
+    private static func pgrepChildren(of pid: pid_t) -> [pid_t] {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+        task.arguments = ["-P", String(pid)]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = FileHandle.nullDevice
+
+        do {
+            try task.run()
+        } catch {
+            return []
+        }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+
+        return (String(data: data, encoding: .utf8) ?? "")
+            .split(separator: "\n")
+            .compactMap { pid_t($0.trimmingCharacters(in: .whitespaces)) }
+    }
+}


### PR DESCRIPTION
Closes #26

`BashService.execute` called `readDataToEndOfFile()` and `waitUntilExit()` with no bound, so one wedged external tool held an entire collection forever — the module never reported, the payload never shipped, and the device stayed otherwise healthy, which is far harder to notice than a crash. Two runs were found wedged on `mdatp health` against a hung Defender daemon, one for thirty minutes and one for nearly six hours.

**A timeout alone would not have fixed it.** Commands run as `/bin/bash -c`, and the inherited pipe passes to bash's own children — so a wedged *grandchild* keeps the write end open and the blocking read never sees EOF even after bash is killed. `ProcessRunner` resolves the timeout independently of EOF and SIGKILLs the whole descendant tree, not just the direct child.

**There was also a deadlock with no misbehaving command involved.** The same function drained stdout to EOF and only then read stderr, so anything writing more than a 64 KB pipe buffer to stderr hung both sides permanently. Both pipes are now drained concurrently through readability handlers.

## Compatibility

Non-zero exit still throws `executionFailed`, so the 17 existing call sites are unaffected. A timeout throws the new `BashError.timedOut`, which `executeWithFallback` already treats like any other failure — a stuck collector degrades to an empty result rather than taking its module down. Default budget is 180s per command, with `system_profiler` given 300s because it is legitimately slow on large data types.

`OSQueryService` already had an equivalent timeout; `ProcessRunner` deliberately follows its terminate → 2s grace → kill shape rather than introducing a second idiom.

## Verification

Behavioural harness against the new implementation:

```
PASS normal: hello
PASS nonzero: threw executionFailed as before
PASS stderr-backpressure: 0.0s, stdout=done-stdout
PASS wedged-grandchild: timed out after 7.4s (budget 5s)
```

The wedged-grandchild case is `sleep 600 & wait` — bash exits its foreground but the child holds the pipe, exactly the shape that defeated the old code. No orphaned `sleep` remained afterwards, confirming the tree kill.

The same stderr case run against the **previous** implementation, verbatim, was still running after 20 seconds and had to be killed — confirming that deadlock was real rather than theoretical.

End-to-end, `--run-modules security,management,identity` completes in 3m45s and all three modules produce full payloads, with the Platform SSO and MDM certificate fields still correct.

## Not covered here

`readDataToEndOfFile()` on an unbounded pipe appears in roughly twenty other places — ad-hoc `Process` usage in individual module processors, `SystemUtils`, `ApplicationUsageService`, `PythonService`. Those should move onto `ProcessRunner` as a separate sweep; this change covers the shared path that every module's bash fallback goes through.