### PR TITLE
Route ad-hoc process execution through ProcessRunner

### DIFF
--- a/Sources/DataCollection/Modules/HardwareModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/HardwareModuleProcessor.swift
@@ -2561,47 +2561,36 @@ private func collectBatteryInfo() async throws -> [String: Any] {
     /// Use this for user home directories which can contain millions of files
     /// Includes timeout to prevent hanging on TCC-protected directories
     private func fastDirectorySizeWithDu(path: String, timeoutSeconds: Int = 30) async -> Int64? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/du")
-        // -s = summary only, -k = kilobytes, -x = don't cross filesystem boundaries
-        process.arguments = ["-skx", path]
-        
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()  // Suppress error output (permission denied, etc.)
-        
-        do {
-            try process.run()
-            
-            // Wait with timeout to prevent hanging on TCC-protected directories
-            let deadline = Date().addingTimeInterval(Double(timeoutSeconds))
-            while process.isRunning && Date() < deadline {
-                try await Task.sleep(nanoseconds: 100_000_000)  // 100ms
-            }
-            
-            if process.isRunning {
-                // Timeout reached - terminate the process
-                print("[\(timestamp())] du timeout for: \(path) - terminating")
-                process.terminate()
-                return nil
-            }
-            
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            if let output = String(data: data, encoding: .utf8) {
-                // Output format: "123456\t/path/to/directory"
-                let components = output.components(separatedBy: "\t")
-                if let sizeStr = components.first?.trimmingCharacters(in: .whitespacesAndNewlines),
-                   let sizeKB = Int64(sizeStr) {
-                    return sizeKB * 1024  // Convert KB to bytes
-                }
-            }
-        } catch {
-            if process.isRunning {
-                process.terminate()
-            }
+        // -s = summary only, -k = kilobytes, -x = don't cross filesystem boundaries.
+        // stderr is discarded by the caller: du reports permission-denied per directory and
+        // that noise is expected here.
+        //
+        // Previously this polled `process.isRunning` every 100ms against a deadline and then
+        // read the pipe. The poll bounded the wait but terminating du does not close a pipe
+        // still held open by anything it spawned, and the read that followed was unbounded —
+        // so the timeout path could still block. ProcessRunner resolves the timeout without
+        // depending on EOF and kills the whole process tree.
+        let result = try? await ProcessRunner.run(
+            executable: "/usr/bin/du",
+            arguments: ["-skx", path],
+            timeout: TimeInterval(timeoutSeconds),
+            label: "du -skx \(path)"
+        )
+
+        guard let result = result else { return nil }
+
+        if result.timedOut {
+            ConsoleFormatter.writeDebug("du exceeded its \(timeoutSeconds)s budget for: \(path)")
             return nil
         }
-        
+
+        // Output format: "123456\t/path/to/directory"
+        let components = result.standardOutput.components(separatedBy: "\t")
+        if let sizeStr = components.first?.trimmingCharacters(in: .whitespacesAndNewlines),
+           let sizeKB = Int64(sizeStr) {
+            return sizeKB * 1024  // Convert KB to bytes
+        }
+
         return nil
     }
     

--- a/Sources/DataCollection/Modules/InstallsModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/InstallsModuleProcessor.swift
@@ -326,23 +326,19 @@ public class InstallsModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             fi
             """
         
-        // Execute bash script
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
-        process.arguments = ["-c", bashScript]
-        
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
-        
+        // Execute bash script through ProcessRunner. This reads a Munki log and truncates at
+        // 100KB below, so it deliberately expects output well past the 64KB pipe buffer — and
+        // the previous `waitUntilExit()` before reading deadlocked at exactly that point. The
+        // machines with the most log data were the ones that hung.
         do {
-            try process.run()
-            process.waitUntilExit()
-            
-            let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
-            if let output = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !output.isEmpty {
+            let result = try await ProcessRunner.bash(bashScript)
+            if result.timedOut {
+                ConsoleFormatter.writeDebug("Munki log read exceeded its time budget")
+                return ""
+            }
+
+            let output = result.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !output.isEmpty {
                 // Limit to reasonable size (100KB max to avoid bloating the payload)
                 let maxSize = 100_000
                 if output.count > maxSize {
@@ -408,16 +404,13 @@ public class InstallsModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         
         // Get Munki version from the binary
         if FileManager.default.fileExists(atPath: "/usr/local/munki/managedsoftwareupdate") {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/local/munki/managedsoftwareupdate")
-            process.arguments = ["--version"]
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = Pipe()
-            try? process.run()
-            process.waitUntilExit()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            if let version = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !version.isEmpty {
+            let result = try? await ProcessRunner.run(
+                executable: "/usr/local/munki/managedsoftwareupdate",
+                arguments: ["--version"],
+                timeout: 30
+            )
+            let version = (result?.standardOutput ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if result?.timedOut != true, !version.isEmpty {
                 info["version"] = version
             }
         }

--- a/Sources/DataCollection/Modules/ManagementModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/ManagementModuleProcessor.swift
@@ -778,22 +778,16 @@ public class ManagementModuleProcessor: BaseModuleProcessor, @unchecked Sendable
     
     /// Fallback method using profiles list command (basic info only)
     private func collectInstalledProfilesBasic() async throws -> [[String: Any]] {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/profiles")
-        process.arguments = ["list"]
-        
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = Pipe()
-        
-        try process.run()
-        process.waitUntilExit()
-        
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        guard let output = String(data: data, encoding: .utf8) else {
+        let result = try await ProcessRunner.run(
+            executable: "/usr/bin/profiles",
+            arguments: ["list"]
+        )
+        guard !result.timedOut else {
+            ConsoleFormatter.writeDebug("profiles list exceeded its time budget")
             return []
         }
-        
+        let output = result.standardOutput
+
         var profiles: [[String: Any]] = []
         var currentProfile: [String: Any]? = nil
         
@@ -945,19 +939,16 @@ public class ManagementModuleProcessor: BaseModuleProcessor, @unchecked Sendable
     
     // MARK: - Helper to execute bash commands
     
-    private func executeBashCommand(_ command: String) async throws -> String {
-        let process = Process()
-        let pipe = Pipe()
-        
-        process.standardOutput = pipe
-        process.standardError = pipe
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
-        process.arguments = ["-c", command]
-        
-        try process.run()
-        process.waitUntilExit()
-        
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8) ?? ""
+    /// Runs through ProcessRunner rather than driving Process directly. The previous version
+    /// called `waitUntilExit()` and only then read the pipe, which deadlocks once a command
+    /// produces more than a 64KB pipe buffer — a hang determined by output size rather than by
+    /// any misbehaving command, and this helper takes arbitrary commands.
+    private func executeBashCommand(_ command: String, timeout: TimeInterval = ProcessRunner.defaultTimeout) async throws -> String {
+        let result = try await ProcessRunner.bash(command, timeout: timeout)
+        if result.timedOut {
+            ConsoleFormatter.writeDebug("Management command exceeded its \(Int(timeout))s budget: \(command)")
+        }
+        // Preserves the previous behaviour of merging stderr into the returned text.
+        return result.standardOutput + result.standardError
     }
 }

--- a/Sources/DataCollection/Modules/SecurityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/SecurityModuleProcessor.swift
@@ -1635,21 +1635,21 @@ public class SecurityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         ]
     }
     
-    /// Simple bash command execution helper for EDR collection
-    private func executeBashScript(_ script: String) async throws -> String {
-        let process = Process()
-        let pipe = Pipe()
-        
-        process.standardOutput = pipe
-        process.standardError = pipe
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
-        process.arguments = ["-c", script]
-        
-        try process.run()
-        process.waitUntilExit()
-        
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        return String(data: data, encoding: .utf8) ?? ""
+    /// Simple bash command execution helper for EDR collection.
+    ///
+    /// Runs through ProcessRunner rather than driving Process directly. The previous version
+    /// called `waitUntilExit()` and only then read the pipe, which deadlocks outright once a
+    /// command produces more than a 64KB pipe buffer: the child blocks writing, the parent
+    /// waits for an exit that can never come. That is a hang determined by output size, not by
+    /// any misbehaving command, and this helper takes arbitrary commands.
+    private func executeBashScript(_ script: String, timeout: TimeInterval = ProcessRunner.defaultTimeout) async throws -> String {
+        let result = try await ProcessRunner.bash(script, timeout: timeout)
+        if result.timedOut {
+            ConsoleFormatter.writeDebug("EDR command exceeded its \(Int(timeout))s budget: \(script)")
+        }
+        // Preserves the previous behaviour of merging stderr into the returned text, which
+        // callers of this helper expect.
+        return result.standardOutput + result.standardError
     }
     
     /// Collect Microsoft Defender for Endpoint status via mdatp CLI


### PR DESCRIPTION
Follow-up to #27, which bounded the shared `BashService` path. This sweeps the collectors that drive `Process` directly.

## The pattern

Five sites called `waitUntilExit()` **before** reading the pipe:

```swift
try process.run()
process.waitUntilExit()
let data = pipe.fileHandleForReading.readDataToEndOfFile()
```

That deadlocks outright once a command produces more than a 64 KB pipe buffer — the child blocks writing, the parent waits for an exit that can never come. It is a hang determined by **output size**, not by any misbehaving command. Verified by running the pattern verbatim against a well-behaved loop producing ~250 KB: it never completed and had to be killed.

Exposure is not theoretical:

- `SecurityModuleProcessor.executeBashScript` and `ManagementModuleProcessor.executeBashCommand` are generic helpers taking arbitrary commands, so their exposure is whatever a caller passes.
- `InstallsModuleProcessor` reads a Munki log and **truncates the result at 100 KB** — it explicitly expects output well past the point where the read deadlocks. The machines with the most log data were the ones that hung.
- `collectInstalledProfilesBasic` (`profiles list`) and `managedsoftwareupdate --version` are small in practice but shared the same shape.

`fastDirectorySizeWithDu` polled `isRunning` against a deadline. That bounded the wait but not the read that followed, and terminating `du` does not close a pipe still held open by anything it spawned. It moves onto the same runner rather than keeping a second, weaker timeout of its own.

## Compatibility

Both generic helpers still merge stderr into their returned text, which their callers expect. The `du` output parser is unchanged. Timeouts degrade to an empty result and a debug line rather than throwing, matching how the rest of collection handles a failed probe.

## Verification

`--run-modules security,management,installs,hardware` completes in 1m27s with everything intact: 42 profiles, the MDM certificate (`Microsoft Intune` / `ACME`), Munki version plus a 33 KB run log through the reader that previously deadlocked above 64 KB, and storage entries through the `du` path.

## Still outstanding

Unbounded reads remain in `SystemUtils` (2), `PythonService` (2), `AppUsageWatcher` (2), `ApplicationUsageService` (1), `XPCClient` and `HelperCommandRunner`. They are deliberately excluded here: `SystemUtils` exposes a synchronous API so moving it onto an async runner ripples into its callers and deserves its own change; `PythonService` is legacy the repo forbids extending; the watcher and XPC paths are separate executables reading handles rather than spawning collection commands. `OSQueryService` already has its own timeout race and is fine.

## Unrelated finding

`edrProducts` reports `count: 0, hasEDR: 0` on a machine with Microsoft Defender installed and running. Confirmed **pre-existing** — the binary from before this change reports the same — so it is not a regression here, but EDR detection appears broken and needs its own issue.