### PR TITLE
Recognise SimpleMDM when resolving the MDM provider

### DIFF
--- a/Sources/DataCollection/Modules/ManagementModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/ManagementModuleProcessor.swift
@@ -430,6 +430,7 @@ public class ManagementModuleProcessor: BaseModuleProcessor, @unchecked Sendable
                 *kandji*)                          mdm_provider="Kandji" ;;
                 *awmdm*|*airwatch*|*workspaceone*) mdm_provider="VMware Workspace ONE" ;;
                 *addigy*)                          mdm_provider="Addigy" ;;
+                *simplemdm*)                       mdm_provider="SimpleMDM" ;;
                 *)                                 mdm_provider="$cert_issuer" ;;
             esac
 


### PR DESCRIPTION
One line carried over from #2 before closing it as superseded.

#2 reached the same conclusion about stale MDM identity certificates naming a provider the device had already left — its comment reads *"after a device migrates between MDMs the old identity certificate stays in the System keychain (often valid for years)"*, which is exactly the failure #25 fixed. #25 goes further by resolving the identity from the enrollment profile itself, so the subject, issuer and expiry are correct rather than only the provider label, and derives the provider from the enrollment URL with the same fallback ordering.

The one thing #2 had that #25 does not is SimpleMDM in the provider list. This adds it. (#25 in turn recognises VMware Workspace ONE, which #2 did not.)