### PR TITLE
Consider the check-in URL when resolving the MDM provider

### DIFF
--- a/Sources/DataCollection/Modules/ManagementModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/ManagementModuleProcessor.swift
@@ -418,9 +418,11 @@ public class ManagementModuleProcessor: BaseModuleProcessor, @unchecked Sendable
                 rm -f "$tmp_pem"
             fi
 
-            # Identify the vendor from the enrollment endpoint - what the device actually
-            # talks to - falling back to the issuing CA.
-            check_str=$(printf '%s %s' "$server_url" "$cert_issuer" | tr '[:upper:]' '[:lower:]')
+            # Identify the vendor from the enrollment endpoints - what the device actually
+            # talks to - falling back to the issuing CA. Both ServerURL and CheckInURL are
+            # considered: a profile may carry only one of the two, and the issuer is a stale
+            # signal that survives a migration between MDMs for years.
+            check_str=$(printf '%s %s %s' "$server_url" "$checkin_url" "$cert_issuer" | tr '[:upper:]' '[:lower:]')
             case "$check_str" in
                 *manage.microsoft.com*|*intune*)   mdm_provider="Microsoft Intune" ;;
                 *jamfcloud*|*jamf*)                mdm_provider="Jamf Pro" ;;


### PR DESCRIPTION
Follow-up to #25 and #37.

## Why

`mdm_provider` is resolved by matching the active enrollment endpoint against a list of known vendors, falling back to the identity certificate issuer. Only `ServerURL` was in the match string, even though `CheckInURL` is collected two lines earlier and emitted in the same payload.

The fallback is what makes this bite. The MDM identity certificate lingers in the System keychain for years after a migration between MDMs, so a device whose profile carries a `CheckInURL` but no `ServerURL` reports whatever MDM it used to be enrolled in — the same stale-issuer failure the URL matching was added to fix, through a gap the matching did not cover.

## Change

One line: `check_str` now spans `ServerURL`, `CheckInURL` and the issuer. The `case` arms are untouched, so precedence is unchanged — vendor patterns still win over the issuer fallback.

## Verification

`swift build` clean. Resolution logic exercised standalone:

| ServerURL | CheckInURL | Issuer | Result |
|---|---|---|---|
| empty | `i.manage.microsoft.com` | MicroMDM CA | Microsoft Intune (was: MicroMDM) |
| `i.manage.microsoft.com` | `i.manage.microsoft.com` | MicroMDM CA | Microsoft Intune |
| `mdm.example.org` | `mdm.example.org` | MicroMDM CA | MicroMDM |
| empty | empty | MicroMDM CA | MicroMDM |
| empty | empty | Some Unknown CA | Some Unknown CA |
| `example.jamfcloud.com` | empty | JSS Built-in CA | Jamf Pro |

Only the first row changes. The self-hosted MicroMDM row matters most: its URLs match no vendor pattern, so it must keep resolving through the issuer fallback, and it does.