### PR TITLE
Drop the Apple Events grant from the sample privacy profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,6 @@ ReportMate requires **Full Disk Access** and other privacy permissions to collec
 **Permissions Granted:**
 - Full Disk Access (SystemPolicyAllFiles) - Read `/Library/`, `/System/`, `/Users/`, TCC database
 - System Policy Admin Files - MDM enrollment data, configuration profiles
-- Apple Events - System automation (optional)
 
 **For Enterprise Deployment:**
 Deploy the `ReportMate-PrivacyPermissions.mobileconfig` via your MDM solution (Jamf Pro, Intune, Workspace ONE, etc.) to automatically grant permissions across all managed devices.

--- a/Sources/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig
+++ b/Sources/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig
@@ -39,27 +39,6 @@
 			<integer>1</integer>
 			<key>Services</key>
 			<dict>
-				<key>AppleEvents</key>
-				<array>
-					<dict>
-						<key>AEReceiverCodeRequirement</key>
-						<string>identifier "com.apple.systemevents" and anchor apple</string>
-						<key>AEReceiverIdentifier</key>
-						<string>com.apple.systemevents</string>
-						<key>AEReceiverIdentifierType</key>
-						<string>bundleID</string>
-						<key>Authorization</key>
-						<string>Allow</string>
-						<key>CodeRequirement</key>
-						<string>identifier "com.github.reportmate.managedreportsrunner" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7TF6CSP83S"</string>
-						<key>Comment</key>
-						<string>ReportMate macOS Client - System Events automation</string>
-						<key>Identifier</key>
-						<string>com.github.reportmate.managedreportsrunner</string>
-						<key>IdentifierType</key>
-						<string>bundleID</string>
-					</dict>
-				</array>
 				<key>SystemPolicyAllFiles</key>
 				<array>
 					<dict>


### PR DESCRIPTION
Follow-up to #10.

## Why

The applications module was the client's only sender of Apple Events — an `osascript` call to System Events to list login items. #10 replaced it with `sfltool dumpbtm`, so the `AppleEvents` payload in the sample profile now grants a permission nothing asks for.

Worth removing rather than leaving inert. An Apple Events grant lets the holder drive System Events, which is a much broader capability than reading a login item list. Shipping it in the sample profile also propagates that grant to any admin who adapts the template.

## Change

Removes the `AppleEvents` service block. Full Disk Access and admin-files access are untouched for all three binaries in the collection chain. Also drops the matching bullet from the README permissions list.

## Verification

- `plutil -lint` OK
- Remaining grants confirmed by parsing the profile: `SystemPolicyAllFiles` and `SystemPolicySysAdminFiles`, each for `com.github.reportmate.managedreportsrunner`, `io.osquery.agent` and `macadmins_extension`
- No `osascript`, `System Events`, `AppleScript` or `NSAppleEventDescriptor` reference remains anywhere in `Sources/` (the `applescript_enabled` column in `queries.json` is an osquery field name, not an Apple Event)

## Note for deployers

This is the sample template. Anyone running an adapted copy should drop the same block on their side, but only once the post-#10 client has reached their fleet — removing the grant while an older client is still calling `osascript` reintroduces exactly the consent prompt #10 was fixing.
