### PR TITLE
Stagger the daily deep scan and gzip the check-in body

### DIFF
--- a/Sources/Core/Configuration/ConfigurationManager.swift
+++ b/Sources/Core/Configuration/ConfigurationManager.swift
@@ -238,6 +238,11 @@ public struct ReportMateConfiguration {
     public var validateSSL: Bool = true
     public var timeout: Int = 300 // 5 minutes
 
+    /// Gzip the check-in body before sending. Set CompressPayload to false in
+    /// the managed profile to put a machine back on uncompressed check-ins
+    /// without shipping a new client.
+    public var compressPayload: Bool = true
+
     /// Per-query timeout for built-in osquery tables. Kills the osqueryi process
     /// if it does not return within this bound, so a single misbehaving table
     /// cannot block the rest of a module's collection.
@@ -272,6 +277,7 @@ public struct ReportMateConfiguration {
         if let useAltSystemInfo = other["UseAltSystemInfo"] as? Bool { self.useAltSystemInfo = useAltSystemInfo }
         if let validateSSL = other["ValidateSSL"] as? Bool { self.validateSSL = validateSSL }
         if let timeout = other["Timeout"] as? Int { self.timeout = timeout }
+        if let compressPayload = other["CompressPayload"] as? Bool { self.compressPayload = compressPayload }
         if let queryTimeout = other["QueryTimeoutSeconds"] as? Double { self.queryTimeoutSeconds = queryTimeout }
         else if let queryTimeoutInt = other["QueryTimeoutSeconds"] as? Int { self.queryTimeoutSeconds = Double(queryTimeoutInt) }
         if let extQueryTimeout = other["ExtensionQueryTimeoutSeconds"] as? Double { self.extensionQueryTimeoutSeconds = extQueryTimeout }

--- a/Sources/Core/Services/APIClient.swift
+++ b/Sources/Core/Services/APIClient.swift
@@ -91,8 +91,19 @@ public class APIClient {
 
         do {
             // Encode as JSON dictionary
-            request.httpBody = try JSONSerialization.data(withJSONObject: payload)
-            
+            let body = try JSONSerialization.data(withJSONObject: payload)
+
+            // Compress unless the device has been told not to, or the encoder
+            // declined. Compression is an optimisation and must never cost a
+            // device its check-in, so every failure path here falls back to
+            // sending the body as it was.
+            if configuration.compressPayload, let compressed = GzipEncoder.compress(body) {
+                request.httpBody = compressed
+                request.setValue("gzip", forHTTPHeaderField: "Content-Encoding")
+            } else {
+                request.httpBody = body
+            }
+
             let (data, response) = try await session.data(for: request)
             
             guard let httpResponse = response as? HTTPURLResponse else {

--- a/Sources/Core/Utils/GzipEncoder.swift
+++ b/Sources/Core/Utils/GzipEncoder.swift
@@ -1,0 +1,94 @@
+import Compression
+import Foundation
+
+/// Wraps Apple's raw-DEFLATE encoder in a gzip container.
+///
+/// A full collection serializes to a megabyte or more of highly repetitive
+/// module JSON, and gzip takes about an eighth of that to the wire. A body
+/// that spends less time in flight has a correspondingly smaller window in
+/// which the upload can be interrupted, and an interrupted upload is by far
+/// the most common way a check-in is turned away.
+///
+/// `COMPRESSION_ZLIB` is Apple's name for bare DEFLATE with no zlib header and
+/// no checksum, so it cannot be sent as-is under any Content-Encoding without
+/// guessing which of the two readings of "deflate" the other end implements.
+/// Framing it as gzip removes the ambiguity: the header, CRC and length are
+/// fifteen lines, and what goes on the wire is then unambiguous to every HTTP
+/// stack there is.
+public enum GzipEncoder {
+
+    /// Gzip-compress `data`, or return nil if the encoder could not run.
+    ///
+    /// Returning nil rather than throwing is deliberate: compression is an
+    /// optimisation, and a device must never lose its check-in because the
+    /// payload would not compress. The caller sends the body uncompressed.
+    public static func compress(_ data: Data) -> Data? {
+        guard !data.isEmpty else { return nil }
+
+        let deflated = rawDeflate(data)
+        guard let deflated, !deflated.isEmpty else { return nil }
+
+        var out = Data([
+            0x1f, 0x8b,  // magic
+            0x08,        // DEFLATE
+            0x00,        // no optional fields
+            0x00, 0x00, 0x00, 0x00,  // mtime omitted: it would make an
+                                     // otherwise byte-identical body differ
+                                     // every run for no reader's benefit
+            0x00,        // no extra-compression flags
+            0xff,        // unknown OS
+        ])
+        out.append(deflated)
+        appendLittleEndian(crc32(of: data), to: &out)
+        appendLittleEndian(UInt32(truncatingIfNeeded: data.count), to: &out)
+        return out
+    }
+
+    private static func rawDeflate(_ data: Data) -> Data? {
+        // Worst case for incompressible input is slightly larger than the
+        // source, so the destination has to have headroom or the encode
+        // silently returns 0 and the check-in goes up uncompressed.
+        let capacity = data.count + (data.count / 2) + 64
+        var destination = Data(count: capacity)
+
+        let written = destination.withUnsafeMutableBytes { dst -> Int in
+            guard let dstBase = dst.bindMemory(to: UInt8.self).baseAddress else { return 0 }
+            return data.withUnsafeBytes { src -> Int in
+                guard let srcBase = src.bindMemory(to: UInt8.self).baseAddress else { return 0 }
+                return compression_encode_buffer(
+                    dstBase, capacity,
+                    srcBase, data.count,
+                    nil, COMPRESSION_ZLIB
+                )
+            }
+        }
+
+        guard written > 0 else { return nil }
+        return destination.prefix(written)
+    }
+
+    private static func appendLittleEndian(_ value: UInt32, to data: inout Data) {
+        data.append(contentsOf: [
+            UInt8(truncatingIfNeeded: value),
+            UInt8(truncatingIfNeeded: value >> 8),
+            UInt8(truncatingIfNeeded: value >> 16),
+            UInt8(truncatingIfNeeded: value >> 24),
+        ])
+    }
+
+    private static let crcTable: [UInt32] = (0..<256).map { index -> UInt32 in
+        var value = UInt32(index)
+        for _ in 0..<8 {
+            value = (value & 1 == 1) ? (0xEDB8_8320 ^ (value >> 1)) : (value >> 1)
+        }
+        return value
+    }
+
+    private static func crc32(of data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            crc = crcTable[Int((crc ^ UInt32(byte)) & 0xFF)] ^ (crc >> 8)
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -860,7 +860,13 @@ EOF
 </plist>
 EOF
 
-    # Daily daemon - hardware, peripherals (at 9 AM)
+    # Daily daemon - hardware deep scan, in the hour after 09:00.
+    #
+    # StartCalendarInterval fires at the same absolute instant on every Mac,
+    # so a fixed 09:00 puts the whole fleet on the API in one minute. The
+    # hourly and fourhourly daemons do not have this problem -- StartInterval
+    # counts from daemon load, which is boot time, and that is already spread
+    # across the fleet. Same random-sleep wrapper the allmodules job uses.
     cat > "$APP_LAUNCHDAEMONS/com.github.reportmate.daily.plist" << 'EOF'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -870,11 +876,9 @@ EOF
     <string>com.github.reportmate.daily</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/Applications/Utilities/Managed Reports Runner.app/Contents/MacOS/managedreportsrunner</string>
-        <string>--run-modules</string>
-        <string>hardware</string>
-        <string>--storage-mode</string>
-        <string>deep</string>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>sleep $(/usr/bin/jot -r 1 0 3540); exec "/Applications/Utilities/Managed Reports Runner.app/Contents/MacOS/managedreportsrunner" --run-modules hardware --storage-mode deep</string>
     </array>
     <key>StartCalendarInterval</key>
     <dict>


### PR DESCRIPTION
Closes #42

## Stagger

`com.github.reportmate.daily` used `StartCalendarInterval` at exactly 09:00, and `StartCalendarInterval` fires at the same absolute instant on every Mac, so the whole fleet arrived at the API inside one minute. Aborted uploads concentrate in exactly that shape: 82% of check-ins land in the first 15 minutes of an hour, with the abort peak trailing the load peak by five minutes.

The `hourly` and `fourhourly` daemons are left alone — `StartInterval` counts from daemon load, which is boot time, and that is already spread across the fleet. This is the same random-sleep wrapper the `allmodules` job has always used, whose comment already states the principle.

## Gzip

A full collection serializes to a megabyte or more of highly repetitive module JSON and every one went up uncompressed. Measured on three real device payloads, gzip takes it to about an eighth.

Foundation has no gzip, and `COMPRESSION_ZLIB` is Apple's name for bare DEFLATE with no zlib header and no checksum, so it cannot be sent as-is under any `Content-Encoding` without guessing which of the two readings of "deflate" the other end implements. `GzipEncoder` frames that output as gzip — header, CRC32 and length — and what goes on the wire is then unambiguous to every HTTP stack there is. Verified byte-for-byte against the decoder the API actually uses: 1.2 MB in, correct length out, stream reaching EOF with no unconsumed tail.

Every failure path falls back to sending the body uncompressed, which is why `compress` returns nil rather than throwing: compression is an optimisation and must never cost a device its check-in. `CompressPayload` in the managed profile turns it off outright.

## Verification

`./build.sh --skip-pkg --skip-zip --skip-dmg` builds clean.