### PR TITLE
Ignore worktrees, correct the daily daemon docs, drop decorative emoji

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ dev/
 
 # Per-module version file generated at build time
 Sources/Generated/
+
+# Development worktrees live inside the repo at ./.worktrees/<name>
+/.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,4 +172,14 @@ The installer creates multiple daemons with different schedules:
 - `com.github.reportmate.boot` - Full collection at boot
 - `com.github.reportmate.hourly` - security, profiles, network, management
 - `com.github.reportmate.fourhourly` - applications, inventory, system
-- `com.github.reportmate.daily` - hardware, displays (at 9 AM)
+- `com.github.reportmate.daily` - hardware, displays (random offset within the hour after 09:00)
+
+## Worktrees
+
+Create development worktrees **inside this repo** at `./.worktrees/<name>` — never as sibling `<repo>.worktree` folders next to it. Use the global `git wt` alias, which resolves the repo root and places the worktree under `.worktrees/` from any subdirectory:
+
+```bash
+git wt <name> [branch]
+```
+
+That runs `git worktree add .worktrees/<name> [branch]`. Keep `/.worktrees/` listed in this repo's `.gitignore`.

--- a/docs/MUNKI_INTEGRATION.md
+++ b/docs/MUNKI_INTEGRATION.md
@@ -128,7 +128,7 @@ graph TD
 |---------|-------------|------------|-------|
 | **Execution order** | 1st | 2nd | Guaranteed by filename |
 | **Data isolation** | MunkiReport server | ReportMate API | Separate endpoints |
-| **No conflicts** | ✅ | ✅ | Both can succeed/fail independently |
+| **No conflicts** | Yes | Yes | Both can succeed/fail independently |
 | **Logging** | MunkiReport logs | ReportMate logs | Separate log files |
 | **Performance** | ~2-5 seconds | ~3-8 seconds | Sequential, not parallel |
 
@@ -322,11 +322,11 @@ sudo mv /usr/local/munki/postflight.d/00-original.sh \
 ## Summary
 
 The ReportMate postflight integration:
-- ✅ Preserves existing MunkiReport functionality
-- ✅ Runs automatically after every Munki operation
-- ✅ Supports unlimited additional scripts
-- ✅ Provides detailed logging
-- ✅ Handles errors gracefully (non-blocking)
-- ✅ Zero configuration required after installation
+- Preserves existing MunkiReport functionality
+- Runs automatically after every Munki operation
+- Supports unlimited additional scripts
+- Provides detailed logging
+- Handles errors gracefully (non-blocking)
+- Zero configuration required after installation
 
 Both systems collect complementary data and submit to their respective servers without conflicts.


### PR DESCRIPTION
Closes #44

Three unrelated pieces of drift, all in docs or config.

- **`/.worktrees/` is now ignored.** Development worktrees are created inside the repo, so without this every one shows as untracked and the next `git add -A` commits a second checkout into the repo.
- **`CLAUDE.md` said the daily daemon runs "at 9 AM".** It now draws a random offset within the following hour — a fixed calendar time fires at the same instant on every Mac. The worktree convention is documented alongside it.
- **Decorative check marks removed from `docs/MUNKI_INTEGRATION.md`.** A table cell reading "Yes" and a plain bulleted list say the same thing and survive a terminal, a diff and a screen reader.