### PR TITLE
Stamp every module with a collection time, not just two of them

### DIFF
--- a/Sources/DataCollection/DataCollectionService.swift
+++ b/Sources/DataCollection/DataCollectionService.swift
@@ -187,12 +187,16 @@ public class DataCollectionService {
         // Create ISO8601 date formatter for consistent timestamp formatting
         let isoFormatter = ISO8601DateFormatter()
         isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        // One instant for the whole payload, so every module stamped by this run
+        // carries the same value and a reader can group by it.
+        let collectedAt = isoFormatter.string(from: Date())
         
         // Build metadata section (matches Windows EventMetadata)
         let metadata: [String: Any] = [
             "deviceId": deviceInfo.deviceId,
             "serialNumber": deviceInfo.serialNumber,
-            "collectedAt": isoFormatter.string(from: Date()),
+            "collectedAt": collectedAt,
             "clientVersion": AppVersion.current,
             "platform": "macOS",
             "collectionType": "Full",
@@ -215,9 +219,8 @@ public class DataCollectionService {
             "modules": {
                 var modulesDict: [String: Any] = [:]
                 for (key, data) in moduleResults {
-                    var dict = convertModuleDataToDict(data)
-                    dict["moduleVersion"] = ModuleVersions.version(for: key)
-                    modulesDict[key] = dict
+                    modulesDict[key] = stampModuleEnvelope(
+                        convertModuleDataToDict(data), moduleId: key, collectedAt: collectedAt)
                 }
                 return modulesDict
             }()
@@ -225,10 +228,8 @@ public class DataCollectionService {
         
         // Assign module data to top-level fields (mirrors Windows AssignModuleDataToPayload)
         for (moduleId, moduleData) in moduleResults {
-            var moduleDict = convertModuleDataToDict(moduleData)
-            
-            // Stamp per-module version from build-time git history
-            moduleDict["moduleVersion"] = ModuleVersions.version(for: moduleId)
+            let moduleDict = stampModuleEnvelope(
+                convertModuleDataToDict(moduleData), moduleId: moduleId, collectedAt: collectedAt)
             
             // Map module IDs to top-level payload keys (matching Windows structure)
             switch moduleId.lowercased() {
@@ -263,6 +264,32 @@ public class DataCollectionService {
         return payload
     }
     
+    /// Stamp the envelope fields every module carries onto its serialized dict.
+    ///
+    /// collectedAt was previously set by hand inside individual processors, and
+    /// only two of eleven ever did it -- so eight of ten modules reached the API
+    /// with no collection time at all, while the Windows client emitted one for
+    /// every module. Without it there is no way to tell a module that was
+    /// refreshed on this run from one whose stored row has not moved in months,
+    /// because a module's own content timestamps report what the underlying
+    /// source last wrote, not when we last looked. A Munki installs document
+    /// frozen since March looks identical either way.
+    ///
+    /// Stamping here rather than in each processor is what makes it hold: a new
+    /// module gets the field by existing, not by remembering. A processor that
+    /// sets its own collectedAt still wins, since that is the true collection
+    /// instant and this is the moment the payload was assembled.
+    private func stampModuleEnvelope(
+        _ dict: [String: Any], moduleId: String, collectedAt: String
+    ) -> [String: Any] {
+        var dict = dict
+        dict["moduleVersion"] = ModuleVersions.version(for: moduleId)
+        if dict["collectedAt"] == nil {
+            dict["collectedAt"] = collectedAt
+        }
+        return dict
+    }
+
     /// Convert ModuleData to dictionary for JSON serialization
     /// Extracts the actual data from the module, not the wrapper
     private func convertModuleDataToDict(_ moduleData: ModuleData) -> [String: Any] {

--- a/Sources/ReportMateClient.swift
+++ b/Sources/ReportMateClient.swift
@@ -364,6 +364,29 @@ struct ReportMateClient: AsyncParsableCommand {
                 collectedData[moduleName] = data
             }
         }
+
+        // Stamp every module with the instant this run collected it.
+        //
+        // collectedAt used to be set by hand inside individual processors, and
+        // only hardware and peripherals ever did it -- so eight of ten modules
+        // reached the API with no collection time at all, while the Windows
+        // client emitted one for every module from its base model. Without it
+        // there is no way to tell a module refreshed on this run from one whose
+        // stored row has not moved in months: a module's own content timestamps
+        // report what the underlying source last wrote, not when we last looked,
+        // so a Munki installs document frozen since March reads identically
+        // whether the collector ran daily or died in the spring.
+        //
+        // Stamping here rather than in each processor is what makes it hold: a
+        // new module gets the field by existing, not by someone remembering. A
+        // processor that sets its own collectedAt keeps it, since that is the
+        // true collection instant and this is only the end of the run.
+        let collectedAtStamp = ISO8601DateFormatter().string(from: Date())
+        for (moduleName, value) in collectedData {
+            guard var dict = value as? [String: Any], dict["collectedAt"] == nil else { continue }
+            dict["collectedAt"] = collectedAtStamp
+            collectedData[moduleName] = dict
+        }
         
         // Display completion status
         let completionTimestamp = dateFormatter.string(from: Date())


### PR DESCRIPTION
Closes #46

Measured against production: the Windows client reports `collectedAt` on **all ten** modules, macOS on **two**.

```
Windows CTBP0Q2      applications hardware identity installs inventory
                     management network peripherals security system   -> 10/10
macOS   H4TJ610BQ7H6 hardware peripherals                             -> 2/10
```

The cause is that `collectedAt` is set by hand inside `HardwareModuleProcessor` and `PeripheralsModuleProcessor` and nowhere else, while Windows inherits it from `BaseModuleModels` where it defaults to `DateTime.UtcNow` — present by construction. `InstallsModels.swift` declares a `collectionTimestamp`, but that field never reaches the wire.

**Why it matters.** Without a collection time there is no way to tell a module refreshed on this run from one whose stored row has not moved in months. A module's own content timestamps report what the underlying source last wrote, not when we last looked — a Munki installs document frozen since March reads identically whether the collector ran daily or died in the spring.

**Stamped at the end of the run, not inside each processor.** That is what makes it hold: a new module gets the field by existing, not by someone remembering. A processor that already sets its own `collectedAt` keeps it, since that is the true collection instant.

**Both payload builders are stamped.** `ReportMateClient` assembles the payload for `--run-modules` (what the launchd daemons use); `DataCollectionService` builds its own for the path `ReportMateCore` drives. Two assemblers is the underlying fragility and is worth collapsing, but not here — leaving one unstamped would reproduce the bug on whichever path the caller happened to take.

**Verified on a real collection**, not by inspection:

```
metadata : 2026-08-26T03:10:18Z
system   : 2026-08-26T03:10:18Z
network  : 2026-08-26T03:10:18Z
```

No Windows change — it already reports all ten.