### PR TITLE
Count one launch per app-open, and start the watcher in one ps call

### DIFF
--- a/Sources/Watcher/Database/AppUsageDatabase.swift
+++ b/Sources/Watcher/Database/AppUsageDatabase.swift
@@ -200,9 +200,16 @@ public final class AppUsageDatabase: @unchecked Sendable {
         }
     }
     
-    /// Mark orphaned sessions (no end time) with unknown duration
-    /// Called at watcher startup to handle sessions from previous crashes
-    public func markOrphanedSessions() throws {
+    /// Close the sessions left open by a previous run, stamping them with the
+    /// unknown-duration sentinel. Called at watcher startup.
+    ///
+    /// `live` carries the sessions whose process is still running, established
+    /// by `reconcileWithRunningProcesses`. Those are not orphans: closing one
+    /// ends a run that has not ended, and the replacement session opened in its
+    /// place books a second launch for the same app-open and throws away the
+    /// reporting watermark. Reconciliation therefore runs first and its result
+    /// is passed here.
+    public func markOrphanedSessions(excluding live: Set<Int64> = []) throws {
         guard let db = db else {
             throw AppUsageDatabaseError.notInitialized
         }
@@ -210,51 +217,98 @@ public final class AppUsageDatabase: @unchecked Sendable {
         let formatter = ISO8601DateFormatter()
         let now = formatter.string(from: Date())
         
-        // Find all sessions with no end time and mark them with -1 duration (unknown)
-        let orphaned = sessions.filter(endTime == nil)
+        var orphaned = sessions.filter(endTime == nil)
+        if !live.isEmpty {
+            orphaned = orphaned.filter(!live.contains(id))
+        }
         try db.run(orphaned.update(
             endTime <- now,
             durationSeconds <- -1  // -1 indicates unknown/interrupted duration
         ))
     }
     
-    /// Reconcile with currently running processes at startup
-    /// Creates sessions for apps that were already running before watcher started
-    public func reconcileWithRunningProcesses(_ runningApps: [(bundleId: String?, name: String, path: String, user: String, pid: Int, startTime: Date)]) throws {
+    /// Reconcile the database with the applications running right now, and
+    /// return the ids of the sessions that describe them.
+    ///
+    /// Called at watcher startup, before the orphan sweep, so that a session
+    /// whose process survived the restart is carried forward instead of being
+    /// closed and replaced. An app the user never quit is one continuous
+    /// app-open: reopening it as a new session counts a second launch for it
+    /// and resets the reporting watermark, so every application running at the
+    /// moment of a reboot or a client upgrade inflated the launch count by one.
+    ///
+    /// Applications that were opened while the watcher was down have no session
+    /// yet and get one here, stamped with the real process start time.
+    @discardableResult
+    public func reconcileWithRunningProcesses(_ runningApps: [RunningApplication]) throws -> Set<Int64> {
         guard let db = db else {
             throw AppUsageDatabaseError.notInitialized
         }
         
         let formatter = ISO8601DateFormatter()
+        var live: Set<Int64> = []
         
         for app in runningApps {
-            // Check if we already have an active session for this PID
-            let existing = sessions
-                .filter(pid == Int64(app.pid))
-                .filter(endTime == nil)
-            
-            if try db.pluck(existing) == nil {
-                // No existing session, create one
-                let insert = sessions.insert(
-                    bundleId <- app.bundleId,
-                    appName <- app.name,
-                    path <- app.path,
-                    user <- app.user,
-                    self.pid <- Int64(app.pid),
-                    startTime <- formatter.string(from: app.startTime),
-                    endTime <- nil as String?,
-                    durationSeconds <- 0,
-                    foregroundSeconds <- 0,
-                    activeSeconds <- 0,
-                    reportedTotalSeconds <- 0,
-                    reportedForegroundSeconds <- 0,
-                    reportedActiveSeconds <- 0,
-                    reportedAt <- nil as String?,
-                    transmitted <- false
-                )
-                _ = try db.run(insert)
+            if let carried = try continuedSession(for: app, formatter: formatter, db: db) {
+                live.insert(carried)
+                continue
             }
+            
+            let insert = sessions.insert(
+                bundleId <- app.bundleId,
+                appName <- app.name,
+                path <- app.path,
+                user <- app.user,
+                self.pid <- Int64(app.pid),
+                startTime <- formatter.string(from: app.startTime ?? Date()),
+                endTime <- nil as String?,
+                durationSeconds <- 0,
+                foregroundSeconds <- 0,
+                activeSeconds <- 0,
+                reportedTotalSeconds <- 0,
+                reportedForegroundSeconds <- 0,
+                reportedActiveSeconds <- 0,
+                reportedAt <- nil as String?,
+                transmitted <- false
+            )
+            live.insert(try db.run(insert))
         }
+        
+        return live
+    }
+    
+    /// The open session already describing this process, if there is one.
+    ///
+    /// A PID alone does not identify a process — the kernel reuses numbers, so
+    /// a session left open by a machine that lost power can carry the same PID
+    /// as something unrelated after the reboot. Two further conditions settle
+    /// it: the bundle path must agree, and the session cannot have begun before
+    /// the process it claims to describe. `ps` reports whole seconds and
+    /// truncates, and a session is stamped no earlier than the launch
+    /// notification that follows the exec, so a genuine match always satisfies
+    /// `session.startTime >= process.startTime`.
+    ///
+    /// When the process start time could not be read the pair is matched on
+    /// PID and path alone. That is the weaker test, but the alternative —
+    /// treating the running app as new — is the double count this exists to
+    /// prevent.
+    private func continuedSession(
+        for app: RunningApplication,
+        formatter: ISO8601DateFormatter,
+        db: Connection
+    ) throws -> Int64? {
+        let candidates = sessions
+            .filter(pid == Int64(app.pid))
+            .filter(endTime == nil)
+            .filter(path == app.path)
+            .order(startTime.desc)
+        
+        guard let row = try db.pluck(candidates) else { return nil }
+        guard let processStart = app.startTime else { return row[id] }
+        guard let sessionStart = formatter.date(from: row[startTime]),
+              sessionStart >= processStart else { return nil }
+        
+        return row[id]
     }
     
     // MARK: - Query Methods
@@ -458,6 +512,31 @@ public final class AppUsageDatabase: @unchecked Sendable {
 }
 
 // MARK: - Supporting Types
+
+/// One application found running when the watcher starts.
+///
+/// `startTime` is the moment the kernel started the process, and is optional
+/// because it is read from `ps` and can fail. Nil means unknown rather than
+/// now: a session stamped with the current time for an app that has been open
+/// since Tuesday claims a launch on the wrong day, and reconciliation needs to
+/// tell "started just now" apart from "could not tell".
+public struct RunningApplication: Sendable {
+    public let bundleId: String?
+    public let name: String
+    public let path: String
+    public let user: String
+    public let pid: Int
+    public let startTime: Date?
+
+    public init(bundleId: String?, name: String, path: String, user: String, pid: Int, startTime: Date?) {
+        self.bundleId = bundleId
+        self.name = name
+        self.path = path
+        self.user = user
+        self.pid = pid
+        self.startTime = startTime
+    }
+}
 
 public struct AppUsageSessionRecord: Sendable {
     public let id: Int64

--- a/Sources/Watcher/Watcher/AppUsageWatcher.swift
+++ b/Sources/Watcher/Watcher/AppUsageWatcher.swift
@@ -55,16 +55,17 @@ public final class AppUsageWatcher: @unchecked Sendable {
         // Initialize database
         try database.initialize()
         
-        // Mark any orphaned sessions from previous run
-        try database.markOrphanedSessions()
+        // Reconcile before sweeping. An application still running is one
+        // continuous app-open, so its session has to survive the sweep with its
+        // launch and its reporting watermark intact; only the sessions with no
+        // process behind them any more are orphans.
+        let live = try reconcileRunningApps()
+        try database.markOrphanedSessions(excluding: live)
         logger.info("Marked orphaned sessions from previous run")
 
         // Prune expired sessions once at startup, then daily via timer
         runRetentionSweep()
         startPruneTimer()
-
-        // Reconcile with currently running apps
-        try reconcileRunningApps()
         
         // Set up workspace notifications
         setupNotificationObservers()
@@ -299,11 +300,13 @@ public final class AppUsageWatcher: @unchecked Sendable {
 
     // MARK: - Reconciliation
     
-    /// Reconcile database with currently running applications
-    /// Called at startup to capture apps that were already running
-    private func reconcileRunningApps() throws {
+    /// Reconcile the database with the applications running right now, and
+    /// return the sessions that describe them so the orphan sweep can spare
+    /// them. Called at startup to pick up apps that were already open.
+    @discardableResult
+    private func reconcileRunningApps() throws -> Set<Int64> {
         let runningApps = NSWorkspace.shared.runningApplications
-        var appsToReconcile: [(bundleId: String?, name: String, path: String, user: String, pid: Int, startTime: Date)] = []
+        var appsToReconcile: [RunningApplication] = []
         
         for app in runningApps {
             guard let bundleURL = app.bundleURL,
@@ -317,21 +320,19 @@ public final class AppUsageWatcher: @unchecked Sendable {
             let pid = Int(app.processIdentifier)
             let user = processOwner(pid: pid) ?? NSUserName()
 
-            // Try to get actual start time from process info
-            let startTime = getProcessStartTime(pid: pid) ?? Date()
-            
-            appsToReconcile.append((
+            appsToReconcile.append(RunningApplication(
                 bundleId: bundleId,
                 name: appName,
                 path: path,
                 user: user,
                 pid: pid,
-                startTime: startTime
+                startTime: getProcessStartTime(pid: pid)
             ))
         }
         
-        try database.reconcileWithRunningProcesses(appsToReconcile)
+        let live = try database.reconcileWithRunningProcesses(appsToReconcile)
         logger.info("Reconciled \(appsToReconcile.count) running applications")
+        return live
     }
     
     /// The user a running process belongs to, or nil if it can't be determined.

--- a/Sources/Watcher/Watcher/AppUsageWatcher.swift
+++ b/Sources/Watcher/Watcher/AppUsageWatcher.swift
@@ -29,6 +29,10 @@ public final class AppUsageWatcher: @unchecked Sendable {
     // than the safety-net retention, independent of the transmit/confirm path.
     private var pruneTimer: DispatchSourceTimer?
     private static let pruneInterval: TimeInterval = 86_400
+
+    // Time budget for a `ps` invocation. Nothing the watcher runs should be
+    // able to block its startup indefinitely.
+    private static let psTimeout: TimeInterval = 15
     
     // MARK: - Initialization
     
@@ -305,28 +309,27 @@ public final class AppUsageWatcher: @unchecked Sendable {
     /// them. Called at startup to pick up apps that were already open.
     @discardableResult
     private func reconcileRunningApps() throws -> Set<Int64> {
-        let runningApps = NSWorkspace.shared.runningApplications
-        var appsToReconcile: [RunningApplication] = []
-        
-        for app in runningApps {
+        let trackable = NSWorkspace.shared.runningApplications.compactMap { app -> (NSRunningApplication, URL)? in
             guard let bundleURL = app.bundleURL,
                   isTrackableApplication(bundleURL: bundleURL) else {
-                continue
+                return nil
             }
-            
-            let bundleId = app.bundleIdentifier
-            let appName = app.localizedName ?? bundleURL.deletingPathExtension().lastPathComponent
-            let path = bundleURL.path
+            return (app, bundleURL)
+        }
+        
+        // One `ps` for the whole set, before the loop, rather than two inside it.
+        let details = processDetails(pids: trackable.map { Int($0.0.processIdentifier) })
+        
+        var appsToReconcile: [RunningApplication] = []
+        for (app, bundleURL) in trackable {
             let pid = Int(app.processIdentifier)
-            let user = processOwner(pid: pid) ?? NSUserName()
-
             appsToReconcile.append(RunningApplication(
-                bundleId: bundleId,
-                name: appName,
-                path: path,
-                user: user,
+                bundleId: app.bundleIdentifier,
+                name: app.localizedName ?? bundleURL.deletingPathExtension().lastPathComponent,
+                path: bundleURL.path,
+                user: details[pid]?.user ?? NSUserName(),
                 pid: pid,
-                startTime: getProcessStartTime(pid: pid)
+                startTime: details[pid]?.startTime
             ))
         }
         
@@ -335,70 +338,126 @@ public final class AppUsageWatcher: @unchecked Sendable {
         return live
     }
     
-    /// The user a running process belongs to, or nil if it can't be determined.
+    /// Owner and start time for a set of PIDs, read in a single `ps` call.
     ///
     /// The watcher runs as a root LaunchDaemon, so `NSUserName()` reports the
     /// daemon's own identity rather than the person at the keyboard. Reading the
     /// owner from the observed process attributes each session to the right user
     /// and stays correct across fast user switching. The uid is read rather than
     /// `ps -o user=`, which truncates usernames past eight characters.
-    private func processOwner(pid: Int) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-o", "uid=", "-p", "\(pid)"]
+    ///
+    /// One invocation, not two per application. Startup asked `ps` twice for
+    /// every running app -- roughly 134 spawns for 67 applications, 29 seconds
+    /// on a real machine -- and the watcher sees nothing at all until it
+    /// finishes, so every app opened in that window lost its launch.
+    private func processDetails(pids: [Int]) -> [Int: (user: String?, startTime: Date?)] {
+        guard !pids.isEmpty else { return [:] }
 
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
+        let list = pids.map(String.init).joined(separator: ",")
+        guard let output = runPS(arguments: ["-o", "pid=,uid=,lstart=", "-p", list]) else {
+            return [:]
+        }
 
-        do {
-            try process.run()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            process.waitUntilExit()
+        // "Day Mon DD HH:MM:SS YYYY", with the day of month space-padded. The
+        // padding collapses because the line is split on whitespace runs.
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE MMM d HH:mm:ss yyyy"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
 
-            guard let output = String(data: data, encoding: .utf8)?
-                    .trimmingCharacters(in: .whitespacesAndNewlines),
-                  let uid = uid_t(output),
-                  let entry = getpwuid(uid) else {
-                return nil
+        var details: [Int: (user: String?, startTime: Date?)] = [:]
+        for line in output.split(separator: "\n") {
+            let fields = line.split(separator: " ", omittingEmptySubsequences: true)
+            guard fields.count >= 3, let pid = Int(fields[0]) else { continue }
+
+            var user: String? = nil
+            if let uid = uid_t(fields[1]), let entry = getpwuid(uid) {
+                let name = String(cString: entry.pointee.pw_name)
+                user = name.isEmpty ? nil : name
             }
 
-            let name = String(cString: entry.pointee.pw_name)
-            return name.isEmpty ? nil : name
-        } catch {
-            logger.debug("Could not resolve owner of PID \(pid): \(error)")
-            return nil
+            let started = formatter.date(from: fields[2...].joined(separator: " "))
+            details[pid] = (user: user, startTime: started)
         }
+
+        return details
     }
 
-    /// Get process start time using ps command
-    private func getProcessStartTime(pid: Int) -> Date? {
+    /// The user a running process belongs to, or nil if it can't be determined.
+    private func processOwner(pid: Int) -> String? {
+        processDetails(pids: [pid])[pid]?.user
+    }
+
+    /// Run `ps` under a time budget, returning nil if it does not finish.
+    ///
+    /// The collection path routes external commands through `ProcessRunner`,
+    /// which carries a timeout; the Watcher is a separate executable target and
+    /// cannot reach it without making Core a library, so the two properties
+    /// that matter are reproduced here. Output drains on its own queue, and the
+    /// deadline is a semaphore rather than a read reaching EOF -- a wedged `ps`
+    /// used to hang watcher startup with nothing to stop it.
+    private func runPS(arguments: [String], timeout: TimeInterval = AppUsageWatcher.psTimeout) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-o", "lstart=", "-p", "\(pid)"]
-        
+        process.arguments = arguments
+
+        // `ps` formats lstart through LC_TIME, so an inherited locale changes
+        // the field order -- en_CA prints "Tue 25 Aug", which the month-first
+        // parser below reads as nothing at all. launchd starts the watcher with
+        // no locale set, so the daemon already gets the C ordering; pinning it
+        // keeps the same result when the binary is run by hand from a shell.
+        var environment = ProcessInfo.processInfo.environment
+        environment["LC_ALL"] = "C"
+        environment["LANG"] = "C"
+        process.environment = environment
+
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = FileHandle.nullDevice
-        
+
         do {
             try process.run()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            process.waitUntilExit()
-            
-            guard let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !output.isEmpty else {
-                return nil
-            }
-            
-            // Parse "Day Mon DD HH:MM:SS YYYY" format
-            let formatter = DateFormatter()
-            formatter.dateFormat = "EEE MMM d HH:mm:ss yyyy"
-            formatter.locale = Locale(identifier: "en_US_POSIX")
-            
-            return formatter.date(from: output)
         } catch {
+            logger.debug("Could not run ps \(arguments.joined(separator: " ")): \(error)")
             return nil
+        }
+
+        let collected = OutputBox()
+        let drained = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .utility).async {
+            collected.store(pipe.fileHandleForReading.readDataToEndOfFile())
+            drained.signal()
+        }
+
+        if drained.wait(timeout: .now() + timeout) == .timedOut {
+            logger.warning("ps exceeded its \(Int(timeout))s budget; continuing without it")
+            process.terminate()
+            if drained.wait(timeout: .now() + 2) == .timedOut, process.isRunning {
+                kill(process.processIdentifier, SIGKILL)
+            }
+            return nil
+        }
+
+        process.waitUntilExit()
+        return String(data: collected.value, encoding: .utf8)
+    }
+
+    /// Hands the drained output back from the reader queue. The read has to
+    /// happen off the calling thread so the deadline below does not depend on
+    /// it, which means the buffer crosses a concurrency boundary.
+    private final class OutputBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var data = Data()
+
+        func store(_ new: Data) {
+            lock.lock()
+            data = new
+            lock.unlock()
+        }
+
+        var value: Data {
+            lock.lock()
+            defer { lock.unlock() }
+            return data
         }
     }
     


### PR DESCRIPTION
Two defects in watcher startup, both found while verifying the in-progress usage reporting on real devices.

## A running app's session is closed and reopened across a restart

Startup swept every session with no end time into the unknown-duration sentinel and only then reconciled with the running processes. By that point the session for a still-running app was closed, so reconciliation opened a replacement: two sessions, two launches, for one app-open the user never ended. The first cycle after an upgrade on one device reported 144 launches — 77 orphans plus 67 reconciled — essentially none of them real. Reopening also reset the reporting watermark, so a session that had already been delivered looked unreported.

Reconciliation now runs first and returns the sessions with a live process behind them; the sweep closes everything else. A carried session keeps its id, its launch, and its watermark.

Matching a session to a process needs more than a PID, because the kernel reuses them: the bundle path must agree and the session cannot predate the process it claims to describe. The process start time is also optional through this path now rather than defaulting to the current time — stamping "now" on an app open since Tuesday books its launch on the wrong day, and the matcher needs to tell an unknown start from a start that really is now.

Seconds were never affected. `activeSeconds` and `foregroundSeconds` accumulate per session and are the reportable numbers; this is the launches column only.

## Startup spawned two ps processes per running application

Roughly 134 spawns for 67 apps, and 29 seconds measured between "Marked orphaned sessions" and "Reconciled 67 running applications". The watcher observes nothing while that runs, so applications opened in that window lose their launch.

Reconciliation now asks `ps` once for the whole set with `-o pid=,uid=,lstart=`. Each read is bounded: output drains on its own queue and the deadline is a semaphore rather than a read reaching EOF, so a wedged `ps` can no longer hang startup. The collection path gets this from `ProcessRunner`, which the Watcher target cannot reach without making Core a library, so the two properties that matter are reproduced locally.

`LC_TIME` is pinned to C while doing it. `ps` formats `lstart` through the locale, and an inherited en_CA prints "Tue 25 Aug", which the month-first parser reads as nothing. launchd starts the watcher with no locale set, so the daemon already gets the C ordering and the fleet is unaffected — this keeps the same result when the binary is run by hand, which is how it gets tested.

## Verification

`swift build --product reportmate-appusage` is clean with no warnings. The `ps` batch parse was exercised against real output from a shell carrying an en_CA locale: both the uid resolution and the start-time parse return correct values for every PID asked for.