### PR TITLE
Keep reported foreground under total, and active under foreground

### DIFF
--- a/Sources/DataCollection/Services/ApplicationUsageService.swift
+++ b/Sources/DataCollection/Services/ApplicationUsageService.swift
@@ -610,9 +610,27 @@ public class ApplicationUsageService: @unchecked Sendable {
                 continue
             }
 
+            // The counters are accumulated on different clocks, so the
+            // increments have to be put back in order before they are sent.
+            // Foreground is charged a whole tick at a time, and a tick that
+            // straddles the watermark instant contributes all of its interval
+            // to the window that reads it while only the part after the
+            // watermark is inside that window's wall clock. Total is measured
+            // as wall clock, so foreground can land above it — an application
+            // on screen for longer than it existed, which the fleet showed once
+            // in 1,375 rows, over by 16.7 s against a 30 s tick.
+            //
+            // Active is bounded by foreground for the same reason and by
+            // construction: the watcher charges active seconds only for the tick
+            // it also charged as foreground.
+            //
+            // The excess is dropped rather than deferred. The watermark advances
+            // to the counters actually observed, not to the clamped figures, so
+            // at most one tick per session per cycle goes unreported and nothing
+            // compounds.
             let total = max(0, observedTotalSeconds(of: session) - session.reportedTotalSeconds)
-            let foreground = max(0, session.foregroundSeconds - session.reportedForegroundSeconds)
-            let active = max(0, session.activeSeconds - session.reportedActiveSeconds)
+            let foreground = min(total, max(0, session.foregroundSeconds - session.reportedForegroundSeconds))
+            let active = min(foreground, max(0, session.activeSeconds - session.reportedActiveSeconds))
             guard total > 0 || foreground > 0 || active > 0 else { continue }
 
             for (dateStr, share) in daySpans(from: windowStart, to: windowEnd, formatter: dateFormatter) {


### PR DESCRIPTION
An application cannot be on screen for longer than it existed, and the fleet reported it once.

Foreground seconds accumulate a whole tick at a time. A session's total for a reporting window is wall clock between the previous watermark and the current read. A tick that straddles the watermark instant contributes its entire interval to the window that reads it, while only the part after the watermark is inside that window's wall clock — so foreground can land just above total for an application that held focus continuously.

Measured across the fleet: 1 violating row in 1,375 new-client rows (0.073%), overshoot 16.7 s, under one 30-second tick. Bounded by the tick interval, or by the 90 s sleep/wake clamp, which against a four-hourly collection cycle is at most ~0.2% over-attribution.

The increments are now put back in physical order before they are sent: foreground capped at total, active capped at foreground. Active was already bounded by construction — the watcher charges an active second only for a tick it also charged as foreground — so that cap asserts the invariant rather than changing a number.

The excess is dropped rather than deferred, because the watermark advances to the counters actually observed and not to the clamped figures. At most one tick per session per cycle goes unreported, and nothing compounds.

Small on its own; worth it for the invariant, since the API's own usage validation treats a row in this shape as out of bounds.

`swift build` is clean.