### PR TITLE
Report the serial an input device publishes

### DIFF
--- a/Sources/DataCollection/Modules/PeripheralsModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/PeripheralsModuleProcessor.swift
@@ -289,6 +289,9 @@ public class PeripheralsModuleProcessor: BaseModuleProcessor, @unchecked Sendabl
         let vendor: String
         let vendorId: String
         let productId: String
+        /// Hardware serial where the device publishes one. A pen display is a tracked
+        /// asset, so this is what lets one be identified rather than merely counted.
+        let serialNumber: String
         let transport: String
         /// Every usage pair the device publishes, not only the primary one: a
         /// composite device puts its keyboard, pointer and digitizer collections on
@@ -330,6 +333,7 @@ public class PeripheralsModuleProcessor: BaseModuleProcessor, @unchecked Sendabl
                 "vendor": vendor,
                 "vendorId": vendorId,
                 "productId": productId,
+                "serialNumber": serialNumber,
                 "isBuiltIn": isBuiltIn,
                 "connectionType": connectionType,
                 "deviceType": type
@@ -424,6 +428,7 @@ public class PeripheralsModuleProcessor: BaseModuleProcessor, @unchecked Sendabl
                 vendor: (node["Manufacturer"] as? String) ?? "",
                 vendorId: Self.hexId(node["VendorID"]),
                 productId: Self.hexId(node["ProductID"]),
+                serialNumber: ((node["SerialNumber"] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines),
                 transport: transport,
                 usages: usages
             )


### PR DESCRIPTION
The HID enumeration added in #50 reads name, vendor, ids and transport — but not `SerialNumber`. A pen display attached to a Mac therefore reports no serial, while the same model on Windows does.

A pen display is a tracked asset; without the serial it can be counted but not identified.

One field through the existing plist parse, emitted on every input device that publishes one.

Matches reportmate/reportmate-client-win#66, which carries the same field through the Windows client's flat input list, and reportmate/reportmate-app-web#66, which renders it.

### Verification

Not built locally (no Swift toolchain on this machine) — relying on CI for the compile, same as #50.