### PR TITLE
Label a pen device Pen Input, not Graphics Tablet

### DIFF
--- a/Sources/DataCollection/Modules/PeripheralsModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/PeripheralsModuleProcessor.swift
@@ -348,16 +348,13 @@ public class PeripheralsModuleProcessor: BaseModuleProcessor, @unchecked Sendabl
         }
 
         func asGraphicsTablet() -> [String: Any] {
-            let lowered = name.lowercased()
-            var tabletType = "Graphics Tablet"
-            if lowered.contains("cintiq") || lowered.contains("display") {
-                tabletType = "Pen Display"
-            } else if lowered.contains("intuos") || lowered.contains("bamboo") {
-                tabletType = "Pen Tablet"
-            }
-
+            // What this entry describes is the pen digitizer, whether or not the same
+            // chassis also contains a panel. A pen display's screen is a display, and
+            // the hardware module already enumerates it from EDID with its real model
+            // name and its own serial. Each module reports what it actually collected,
+            // so this one does not infer a screen it never looked at.
             var device = asInputDevice(type: "Graphics Tablet")
-            device["tabletType"] = tabletType
+            device["tabletType"] = "Pen Input"
             return device
         }
     }


### PR DESCRIPTION
A pen device entry describes the **pen digitizer**. Where the same chassis also holds a panel, that panel is a *display* — and the hardware module already enumerates it from EDID, with its real model name and its own serial. On the two pen-display workstations in the field:

```
ANIM-CTQ-35   hardware.displays -> Cintiq 22     Wacom   serial 2FV00Y1001092
ANIM-CTQ-18   hardware.displays -> Cintiq 22HD   Wacom   serial 3GAC000135
```

That is strictly more than the input side can know — the USB node reports only `Wacom Tablet`, with no model anywhere in its descriptors. On CTQ-35 the display's EDID serial is byte-identical to the tablet's USB serial, so the two halves are already joinable where it matters.

Each module reporting only what it collected keeps the input entry from inferring a screen it never looked at, and the pen-only vs pen-plus-display distinction falls out of whether a matching display shows up in hardware.

The `Pen Display` / `Pen Tablet` split this replaces was inferred from the product name, which never carries the model, so it always fell through to the generic label on real hardware anyway.

`deviceType` stays `Graphics Tablet` — that is the machine-readable category the web client groups on, and changing it would strand payloads already collected.

### Verification

Not built locally (no Swift toolchain here) — relying on CI, as with #50 and #54.