### PR TITLE
Detect a broken osquery instead of silently reporting nothing

### DIFF
--- a/Sources/DataCollection/Modules/ModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/ModuleProcessor.swift
@@ -72,6 +72,7 @@ open class BaseModuleProcessor: ModuleProcessor, @unchecked Sendable {
         
         // Try bash fallback (if osquery failed, not available, or returned empty)
         if let bashCmd = bash {
+            await OSQueryHealth.shared.recordDegraded(module: moduleId)
             do {
                 ConsoleFormatter.writeDebug("Trying bash fallback for module \(moduleId)...")
                 let output = try await BashService.execute(bashCmd)
@@ -102,6 +103,11 @@ open class BaseModuleProcessor: ModuleProcessor, @unchecked Sendable {
             return ["items": []]
         }
         
+        // Nothing worked: neither osquery nor bash produced data. Returning [:]
+        // keeps the run alive, but on its own it is indistinguishable from a
+        // device that genuinely has nothing to report, which is how a broken
+        // osquery went unnoticed. Record it so the run reports the gap.
+        await OSQueryHealth.shared.recordStarved(module: moduleId)
         ConsoleFormatter.writeWarning("All data sources exhausted for module \(moduleId), returning empty data")
         return [:]
     }

--- a/Sources/DataCollection/Modules/SystemModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/SystemModuleProcessor.swift
@@ -258,9 +258,16 @@ public class SystemModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         """
         
         let bashScript = """
-            boot_time_sec=$(sysctl -n kern.boottime 2>/dev/null | awk -F'[= ,]' '{print $4}')
+            # kern.boottime reads "{ sec = 1787688050, usec = 313690 } Tue Aug 25 ...".
+            # Splitting on [= ,] yields empty fields, so $4 came back blank and
+            # total_seconds became the current epoch -- a ~56 year uptime.
+            boot_time_sec=$(sysctl -n kern.boottime 2>/dev/null | awk '{gsub(/[{}=,]/, " "); print $2}')
             current_time=$(date +%s)
-            total_seconds=$((current_time - boot_time_sec))
+            if [ -z "$boot_time_sec" ]; then
+                total_seconds=0
+            else
+                total_seconds=$((current_time - boot_time_sec))
+            fi
             
             days=$((total_seconds / 86400))
             hours=$(((total_seconds % 86400) / 3600))

--- a/Sources/DataCollection/OSQueryHealth.swift
+++ b/Sources/DataCollection/OSQueryHealth.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Records whether osquery actually worked during a collection run.
+///
+/// Every module reaches osquery through `executeWithFallback`, which drops to a
+/// bash equivalent when a query fails and returns an empty dictionary when that
+/// fails too. Both paths were silent: an osquery that no longer ran on the host
+/// OS left the device checking in on schedule while reporting almost nothing,
+/// and nothing in the payload said why. This type makes that state explicit so
+/// it can travel to the API as an event instead of being inferred from missing
+/// cards in the UI.
+public actor OSQueryHealth {
+    public static let shared = OSQueryHealth()
+
+    private var probed = false
+    private var healthy = false
+    private var version: String?
+    private var failureReason: String?
+    private var degradedModules: Set<String> = []
+    private var starvedModules: Set<String> = []
+
+    private init() {}
+
+    /// Record the outcome of the once-per-run probe.
+    func recordProbe(healthy: Bool, version: String?, failureReason: String?) {
+        self.probed = true
+        self.healthy = healthy
+        self.version = version
+        self.failureReason = failureReason
+    }
+
+    func hasProbed() -> Bool { probed }
+
+    /// A module fell back to bash because osquery could not answer.
+    func recordDegraded(module: String) { degradedModules.insert(module) }
+
+    /// A module got nothing from osquery *or* bash — it reports no data at all.
+    func recordStarved(module: String) { starvedModules.insert(module) }
+
+    public func snapshot() -> Snapshot {
+        Snapshot(
+            probed: probed,
+            healthy: healthy,
+            version: version,
+            failureReason: failureReason,
+            degradedModules: degradedModules.sorted(),
+            starvedModules: starvedModules.sorted()
+        )
+    }
+
+    public struct Snapshot: Sendable {
+        public let probed: Bool
+        public let healthy: Bool
+        public let version: String?
+        public let failureReason: String?
+        public let degradedModules: [String]
+        public let starvedModules: [String]
+
+        /// True when this run collected less than it should have.
+        public var isDegraded: Bool {
+            !healthy || !starvedModules.isEmpty || !degradedModules.isEmpty
+        }
+
+        /// True when the run is materially broken rather than merely partial.
+        public var isCritical: Bool {
+            !healthy || !starvedModules.isEmpty
+        }
+
+        public var summary: String {
+            if !healthy {
+                return "osquery unavailable: \(failureReason ?? "unknown failure")"
+            }
+            if !starvedModules.isEmpty {
+                return "osquery healthy but \(starvedModules.count) module(s) collected no data: \(starvedModules.joined(separator: ", "))"
+            }
+            return "osquery degraded: \(degradedModules.count) module(s) used bash fallback"
+        }
+
+        public var details: [String: String] {
+            [
+                "osqueryHealthy": String(healthy),
+                "osqueryVersion": version ?? "unknown",
+                "failureReason": failureReason ?? "",
+                "degradedModules": degradedModules.joined(separator: ", "),
+                "starvedModules": starvedModules.joined(separator: ", ")
+            ]
+        }
+    }
+}

--- a/Sources/DataCollection/OSQueryService.swift
+++ b/Sources/DataCollection/OSQueryService.swift
@@ -57,20 +57,94 @@ public class OSQueryService {
     
     /// Check if osquery is available
     public func isAvailable() async -> Bool {
+        // `--version` only proves the file is executable. It exits 0 on a binary
+        // that can no longer open its database or run a query on this OS, which
+        // is exactly how a broken osquery stayed invisible: every module fell
+        // through to bash and the device reported almost nothing. Ask the SQL
+        // engine to answer a real query against a real virtual table instead.
+        let probe = await Self.probe(osqueryPath: osqueryPath)
+
+        if await !OSQueryHealth.shared.hasProbed() {
+            await OSQueryHealth.shared.recordProbe(
+                healthy: probe.healthy,
+                version: probe.version,
+                failureReason: probe.failureReason
+            )
+            if !probe.healthy {
+                ConsoleFormatter.writeWarning(
+                    "osquery is not usable (\(probe.failureReason ?? "unknown failure")) - modules will fall back to bash and may report no data"
+                )
+            }
+        }
+
+        return probe.healthy
+    }
+
+    private struct Probe: Sendable {
+        let healthy: Bool
+        let version: String?
+        let failureReason: String?
+    }
+
+    /// Run the canary query. Mirrors how modules actually invoke osquery
+    /// (`osqueryi --json <query>`) so the probe fails whenever real queries would.
+    private static func probe(osqueryPath: String) async -> Probe {
+        guard FileManager.default.isExecutableFile(atPath: osqueryPath) else {
+            return Probe(healthy: false, version: nil,
+                         failureReason: "not installed at \(osqueryPath)")
+        }
+
         return await withCheckedContinuation { continuation in
             let task = Process()
             task.executableURL = URL(fileURLWithPath: osqueryPath)
-            task.arguments = ["--version"]
-            task.standardOutput = Pipe()
-            task.standardError = Pipe()
-            
+            task.arguments = ["--json", "SELECT version FROM osquery_info;"]
+
+            let outputPipe = Pipe()
+            let errorPipe = Pipe()
+            task.standardOutput = outputPipe
+            task.standardError = errorPipe
+
             do {
                 try task.run()
-                task.waitUntilExit()
-                continuation.resume(returning: task.terminationStatus == 0)
             } catch {
-                continuation.resume(returning: false)
+                continuation.resume(returning: Probe(
+                    healthy: false, version: nil,
+                    failureReason: "failed to launch: \(error.localizedDescription)"))
+                return
             }
+
+            // A wedged osquery must not stall the whole collection run.
+            let watchdog = DispatchWorkItem { if task.isRunning { task.terminate() } }
+            DispatchQueue.global().asyncAfter(deadline: .now() + 20, execute: watchdog)
+
+            let out = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let err = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            task.waitUntilExit()
+            watchdog.cancel()
+
+            guard task.terminationStatus == 0 else {
+                let stderr = String(data: err, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                continuation.resume(returning: Probe(
+                    healthy: false, version: nil,
+                    failureReason: "exit \(task.terminationStatus)"
+                        + (stderr.isEmpty ? "" : ": \(stderr)")))
+                return
+            }
+
+            guard
+                let rows = try? JSONSerialization.jsonObject(with: out) as? [[String: Any]],
+                let version = rows.first?["version"] as? String,
+                !version.isEmpty
+            else {
+                continuation.resume(returning: Probe(
+                    healthy: false, version: nil,
+                    failureReason: "canary query returned no usable rows"))
+                return
+            }
+
+            continuation.resume(returning: Probe(
+                healthy: true, version: version, failureReason: nil))
         }
     }
     

--- a/Sources/ReportMateClient.swift
+++ b/Sources/ReportMateClient.swift
@@ -455,6 +455,27 @@ struct ReportMateClient: AsyncParsableCommand {
             events.append(summaryEvent)
         }
         
+        // Report osquery health. A run where osquery is unusable still produces a
+        // well-formed payload -- every module falls back to bash and the sparse
+        // ones return nothing -- so without this the device looks healthy in the
+        // UI while reporting almost nothing. Emit it as an event so the failure
+        // is visible on the device timeline rather than inferred from blank cards.
+        let osqueryHealth = await OSQueryHealth.shared.snapshot()
+        if osqueryHealth.isDegraded {
+            events.append(ReportMateEvent(
+                moduleId: "collection",
+                eventType: osqueryHealth.isCritical ? "error" : "warning",
+                message: osqueryHealth.summary,
+                timestamp: Date(),
+                stringDetails: osqueryHealth.details
+            ))
+            if osqueryHealth.isCritical {
+                logger.error("\(osqueryHealth.summary)")
+            } else {
+                logger.warning("\(osqueryHealth.summary)")
+            }
+        }
+
         // Create UnifiedDevicePayload matching Windows format for API
         let unifiedPayload = UnifiedDevicePayload(
             metadata: metadata,


### PR DESCRIPTION
`isAvailable()` ran `osqueryi --version`, which exits 0 on a binary that can no longer open its database or run a query. Every module then fell through to its bash fallback, and a module whose fallback also failed returned an empty dictionary silently — the device kept checking in while reporting almost nothing.

Found on RelianceTheatreShared (C02KT014Q7H6), which showed no hardware, no network, and a 20694-day uptime while last-seen was minutes old.

- Probe with the query modules actually use, with a watchdog so a wedged binary cannot stall the run.
- New `OSQueryHealth` actor records the probe, which modules degraded to bash, and which collected nothing.
- Emit that as a `collection` event (error / warning) so the failure reaches the API instead of showing up as blank cards.
- Fix the `kern.boottime` parse that produced the 56-year uptime; the correct parse already existed at line 162 of the same file.

Builds clean (`swift build`). End-to-end verification on a real endpoint is tracked on Azure Boards #4899.

Azure Boards: #4898