### PR TITLE
Always send the package list on multi-package install events

### DIFF
--- a/Sources/ReportMateClient.swift
+++ b/Sources/ReportMateClient.swift
@@ -796,12 +796,13 @@ struct ReportMateClient: AsyncParsableCommand {
                 eventType: "success",
                 message: message,
                 timestamp: Date(),
-                stringDetails: newlyInstalledItems.count <= 5
-                    ? Dictionary(uniqueKeysWithValues: newlyInstalledItems.compactMap { item -> (String, String)? in
-                        guard let name = item["name"] else { return nil }
-                        return (name, item["version"] ?? "")
-                      })
-                    : ["count": String(newlyInstalledItems.count)]
+                // The package list is what the event is for. Runs of more than five used
+                // to send only a count, which left "13 packages installed" with nothing
+                // to expand into on the dashboard.
+                stringDetails: Dictionary(uniqueKeysWithValues: newlyInstalledItems.compactMap { item -> (String, String)? in
+                    guard let name = item["name"] else { return nil }
+                    return (name, item["version"] ?? "")
+                }).merging(["count": String(newlyInstalledItems.count)]) { current, _ in current }
             ))
         }
         


### PR DESCRIPTION
Closes #60

The success event for a run that installed more than five packages sent only a count, so the dashboard could not list what was installed. The name-to-version map is now sent for every run, with the count alongside it.