### PR TITLE
Read Munki's structured session reports and send item-level warnings and errors

### DIFF
--- a/Sources/DataCollection/Modules/InstallsModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/InstallsModuleProcessor.swift
@@ -24,7 +24,15 @@ public class InstallsModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         let homebrew = try await collectHomebrewPackages()
         
         ConsoleFormatter.writeQueryProgress(queryName: "munki_log", current: 3, total: totalSteps)
-        let runLog = try await collectMunkiRunLog()
+        // Newer Munki builds write structured session reports; when present they replace the
+        // log slicing and the regex attribution below, and the legacy plist path is untouched.
+        let sessionReports = MunkiSessionReportReader.read()
+        let runLog: String
+        if let reports = sessionReports, !reports.runLog.isEmpty {
+            runLog = reports.runLog
+        } else {
+            runLog = try await collectMunkiRunLog()
+        }
 
         ConsoleFormatter.writeQueryProgress(queryName: "munki_info", current: 4, total: totalSteps)
         let info = try await collectMunkiInfo(runLog: runLog)
@@ -155,10 +163,15 @@ public class InstallsModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             } ?? [:]
         ]
         
-        // Inject newly installed items info for event message generation
+        // Inject newly installed/removed items info for event message generation
         if var munkiDict = installsData["munki"] as? [String: Any] {
             munkiDict["newlyInstalledCount"] = info["newlyInstalledCount"] as? Int ?? 0
             munkiDict["newlyInstalledItems"] = info["newlyInstalledItems"] as? [[String: String]] ?? []
+            munkiDict["newlyRemovedCount"] = info["newlyRemovedCount"] as? Int ?? 0
+            munkiDict["newlyRemovedItems"] = info["newlyRemovedItems"] as? [[String: String]] ?? []
+            if let reports = sessionReports {
+                munkiDict = Self.applySessionReports(reports, to: munkiDict)
+            }
             installsData["munki"] = munkiDict
         }
         
@@ -170,6 +183,85 @@ public class InstallsModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         return BaseModuleData(moduleId: moduleId, data: installsData)
     }
     
+    // MARK: - Structured session reports (newer Munki builds)
+
+    /// Merges Munki's session reports into the `munki` payload using the field names the
+    /// Windows client sends for Cimian, so the dashboard reads both platforms the same way.
+    /// Sessions stay snake_case as written; events and items are camelCase.
+    static func applySessionReports(_ reports: MunkiSessionReports, to munki: [String: Any]) -> [String: Any] {
+        var dict = munki
+        dict["sessions"] = Array(reports.sessions.prefix(20))
+        dict["events"] = reports.events.map { event -> [String: Any] in
+            var e = MunkiSessionReportReader.camelCased(event)
+            // Windows names these `package` and `version` on the wire.
+            if let name = event["package_name"] { e["package"] = name }
+            if let version = event["package_version"] { e["version"] = version }
+            return e
+        }
+        dict["totalSessions"] = reports.totalSessions
+        if let id = reports.sessionId { dict["sessionId"] = id }
+        if let runType = reports.runType { dict["runType"] = runType }
+        if let duration = reports.durationSeconds { dict["durationSeconds"] = duration }
+        if let status = reports.status { dict["lastSessionStatus"] = status }
+        dict["warningItems"] = reports.warningItems
+        dict["errorItems"] = reports.errorItems
+        if let version = reports.environment["munki_version"] as? String, !version.isEmpty,
+           (dict["version"] as? String ?? "").isEmpty
+        {
+            dict["version"] = version
+        }
+        if let clientId = reports.environment["client_identifier"] as? String, !clientId.isEmpty, dict["clientIdentifier"] == nil {
+            dict["clientIdentifier"] = clientId
+        }
+
+        // Per-item fields from items.json, keyed by exact name. lastError / lastWarning
+        // from the report replace the regex attribution when present.
+        var byName: [String: [String: Any]] = [:]
+        for record in reports.items {
+            if let name = record["item_name"] as? String { byName[name] = record }
+        }
+        var errorByName: [String: String] = [:]
+        for problem in reports.errorItems {
+            if let name = problem["name"] as? String, let message = problem["message"] as? String, errorByName[name] == nil {
+                errorByName[name] = message
+            }
+        }
+        var warningByName: [String: String] = [:]
+        for problem in reports.warningItems {
+            if let name = problem["name"] as? String, let message = problem["message"] as? String, warningByName[name] == nil {
+                warningByName[name] = message
+            }
+        }
+        if let items = dict["items"] as? [[String: Any]] {
+            dict["items"] = items.map { item -> [String: Any] in
+                var i = item
+                let name = item["name"] as? String ?? ""
+                if let record = byName[name] {
+                    i["itemName"] = record["item_name"]
+                    i["itemType"] = record["item_type"]
+                    i["currentStatus"] = record["current_status"]
+                    i["mappedStatus"] = record["current_status"]
+                    i["latestVersion"] = record["latest_version"]
+                    i["lastSeenInSession"] = record["last_seen_in_session"] ?? ""
+                    i["lastAttemptTime"] = record["last_attempt_time"] ?? ""
+                    i["lastAttemptStatus"] = record["last_attempt_status"] ?? ""
+                    i["lastUpdate"] = record["last_update"] ?? ""
+                    i["failureCount"] = record["failure_count"] ?? 0
+                    i["warningCount"] = record["warning_count"] ?? 0
+                    i["installCount"] = 0
+                    if let action = record["action_performed"] { i["actionPerformed"] = action }
+                    if let installed = record["installed_version"] as? String, !installed.isEmpty { i["installedVersion"] = installed }
+                    if let lastError = record["last_error"] as? String, !lastError.isEmpty { i["lastError"] = lastError }
+                    if let lastWarning = record["last_warning"] as? String, !lastWarning.isEmpty { i["lastWarning"] = lastWarning }
+                }
+                if let message = errorByName[name] { i["lastError"] = message }
+                if let message = warningByName[name], (i["lastError"] as? String ?? "").isEmpty { i["lastWarning"] = message }
+                return i
+            }
+        }
+        return dict
+    }
+
     // MARK: - Per-item message consolidation (precise regex extraction)
     
     /// Known Munki warning/error message patterns with a capture group for the exact item name.

--- a/Sources/DataCollection/Services/MunkiSessionReportReader.swift
+++ b/Sources/DataCollection/Services/MunkiSessionReportReader.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// Reads the structured session reports newer Munki builds write beside
+/// ManagedInstallReport.plist:
+///
+///     /Library/Managed Installs/logs/YYYY-MM-DD/HHMM[_n]/{session.json, events.jsonl, run.log}
+///     /Library/Managed Installs/reports/{sessions.json, events.json, items.json, run.log}
+///
+/// The layout and field names are the ones the Windows client reads from Cimian, so the
+/// installs module can carry the same shape on both platforms. `read()` returns nil when
+/// `reports/sessions.json` does not exist, and the caller keeps the legacy plist path.
+struct MunkiSessionReports {
+    /// Raw session records (snake_case, as written), newest first.
+    let sessions: [[String: Any]]
+    /// Raw item records from reports/items.json (snake_case).
+    let items: [[String: Any]]
+    /// The latest finished session's session.json (snake_case).
+    let latestSession: [String: Any]?
+    /// Directory of the latest finished session.
+    let latestSessionDir: String?
+    /// Raw events (snake_case) for the latest finished session.
+    let events: [[String: Any]]
+    /// reports/run.log contents (capped).
+    let runLog: String
+    /// Number of session directories on disk.
+    let totalSessions: Int
+
+    var sessionId: String? { latestSession?["session_id"] as? String }
+    var runType: String? { latestSession?["run_type"] as? String }
+    var status: String? { latestSession?["status"] as? String }
+    var durationSeconds: Int? { latestSession?["duration_seconds"] as? Int }
+    var environment: [String: Any] { latestSession?["environment"] as? [String: Any] ?? [:] }
+    var warningItems: [[String: Any]] { latestSession?["warning_items"] as? [[String: Any]] ?? [] }
+    var errorItems: [[String: Any]] { latestSession?["error_items"] as? [[String: Any]] ?? [] }
+}
+
+enum MunkiSessionReportReader {
+    static let defaultBaseDir = "/Library/Managed Installs"
+    static let runLogCap = 100_000
+
+    static func read(baseDir: String = defaultBaseDir) -> MunkiSessionReports? {
+        let reportsDir = (baseDir as NSString).appendingPathComponent("reports")
+        let logsDir = (baseDir as NSString).appendingPathComponent("logs")
+        guard let sessions = readArray(at: (reportsDir as NSString).appendingPathComponent("sessions.json")) else {
+            return nil
+        }
+        let items = readArray(at: (reportsDir as NSString).appendingPathComponent("items.json")) ?? []
+
+        let dirs = sessionDirectories(logsDir: logsDir)
+        var latestSession: [String: Any]?
+        var latestDir: String?
+        for dir in dirs {
+            guard let session = readObject(at: (dir as NSString).appendingPathComponent("session.json")) else { continue }
+            // A session still marked running belongs to a managedsoftwareupdate that has not
+            // finished; report the previous one rather than a half-written run.
+            if (session["status"] as? String) == "running" { continue }
+            latestSession = session
+            latestDir = dir
+            break
+        }
+
+        var events: [[String: Any]] = []
+        if let latestDir {
+            events = readJSONLines(at: (latestDir as NSString).appendingPathComponent("events.jsonl"))
+        }
+        if events.isEmpty, let sessionId = latestSession?["session_id"] as? String,
+           let reportEvents = readArray(at: (reportsDir as NSString).appendingPathComponent("events.json"))
+        {
+            events = reportEvents.filter { ($0["session_id"] as? String) == sessionId }
+        }
+
+        var runLog = ""
+        if let data = FileManager.default.contents(atPath: (reportsDir as NSString).appendingPathComponent("run.log")),
+           let text = String(data: data, encoding: .utf8)
+        {
+            runLog = text.count > runLogCap ? String(text.suffix(runLogCap)) : text
+        }
+
+        return MunkiSessionReports(
+            sessions: sessions,
+            items: items,
+            latestSession: latestSession,
+            latestSessionDir: latestDir,
+            events: events,
+            runLog: runLog,
+            totalSessions: dirs.count
+        )
+    }
+
+    /// Every session directory under logs/, newest first. Day directories are
+    /// `YYYY-MM-DD`; session directories are `HHMM` with an optional `_2`…`_9` suffix.
+    static func sessionDirectories(logsDir: String) -> [String] {
+        let fm = FileManager.default
+        guard let days = try? fm.contentsOfDirectory(atPath: logsDir) else { return [] }
+        var result: [String] = []
+        for day in days.filter(isDayDirectory).sorted(by: >) {
+            let dayPath = (logsDir as NSString).appendingPathComponent(day)
+            guard let times = try? fm.contentsOfDirectory(atPath: dayPath) else { continue }
+            for time in times.filter(isTimeDirectory).sorted(by: >) {
+                result.append((dayPath as NSString).appendingPathComponent(time))
+            }
+        }
+        return result
+    }
+
+    static func isDayDirectory(_ name: String) -> Bool {
+        guard name.count == 10 else { return false }
+        let parts = name.split(separator: "-")
+        return parts.count == 3 && parts[0].count == 4 && parts[1].count == 2 && parts[2].count == 2
+            && parts.allSatisfy { $0.allSatisfy(\.isNumber) }
+    }
+
+    static func isTimeDirectory(_ name: String) -> Bool {
+        let parts = name.split(separator: "_", maxSplits: 1).map(String.init)
+        guard let time = parts.first, time.count == 4, let value = Int(time), value >= 0, value <= 2359 else { return false }
+        if parts.count == 2 { return parts[1].count == 1 && Int(parts[1]) != nil }
+        return true
+    }
+
+    // MARK: - Key conversion
+
+    /// snake_case → camelCase for the keys of one record, recursively. Sessions are sent
+    /// as written (snake_case) because the dashboard already reads them that way from
+    /// Cimian; events and items are camelCase there.
+    static func camelCased(_ record: [String: Any]) -> [String: Any] {
+        var out: [String: Any] = [:]
+        for (key, value) in record {
+            let newKey = camelCase(key)
+            if let dict = value as? [String: Any] {
+                out[newKey] = camelCased(dict)
+            } else if let array = value as? [[String: Any]] {
+                out[newKey] = array.map(camelCased)
+            } else {
+                out[newKey] = value
+            }
+        }
+        return out
+    }
+
+    static func camelCase(_ key: String) -> String {
+        guard key.contains("_") else { return key }
+        let parts = key.split(separator: "_", omittingEmptySubsequences: true).map(String.init)
+        guard let first = parts.first else { return key }
+        return first + parts.dropFirst().map { $0.prefix(1).uppercased() + $0.dropFirst() }.joined()
+    }
+
+    // MARK: - File helpers
+
+    private static func readArray(at path: String) -> [[String: Any]]? {
+        guard let data = FileManager.default.contents(atPath: path),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return nil }
+        return json
+    }
+
+    private static func readObject(at path: String) -> [String: Any]? {
+        guard let data = FileManager.default.contents(atPath: path),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return json
+    }
+
+    private static func readJSONLines(at path: String) -> [[String: Any]] {
+        guard let data = FileManager.default.contents(atPath: path),
+              let text = String(data: data, encoding: .utf8) else { return [] }
+        return text.split(separator: "\n").compactMap { line in
+            guard let lineData = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else { return nil }
+            return object
+        }
+    }
+}

--- a/Sources/ReportMateClient.swift
+++ b/Sources/ReportMateClient.swift
@@ -772,6 +772,12 @@ struct ReportMateClient: AsyncParsableCommand {
             return events
         }
         
+        // Newer Munki builds ship structured sessions; those events carry per-item
+        // name, version and message in the same shape the Windows client sends for Cimian.
+        if munkiData["sessions"] != nil {
+            return generateMunkiSessionEvents(from: munkiData)
+        }
+
         let errorsString = munkiData["errors"] as? String ?? ""
         let warningsString = munkiData["warnings"] as? String ?? ""
         
@@ -859,6 +865,130 @@ struct ReportMateClient: AsyncParsableCommand {
     }
     
     /// Parse semicolon-separated message strings into array, filtering empty entries
+    /// Events from Munki's structured session reports, mirroring the Windows client's
+    /// Cimian events: one success event per action with the item list, an error event
+    /// with `failed_items`, and a warning event with `warning_items` and the nameless
+    /// `operational_warnings`. Every item carries its message so the dashboard can show it.
+    private func generateMunkiSessionEvents(from munkiData: [String: Any]) -> [ReportMateEvent] {
+        var events: [ReportMateEvent] = []
+        let sessionId = munkiData["sessionId"] as? String ?? ""
+        let runType = munkiData["runType"] as? String ?? ""
+        let duration = munkiData["durationSeconds"] as? Int ?? 0
+        let sessionEvents = munkiData["events"] as? [[String: Any]] ?? []
+        let items = munkiData["items"] as? [[String: Any]] ?? []
+        let warningItems = munkiData["warningItems"] as? [[String: Any]] ?? []
+        let errorItems = munkiData["errorItems"] as? [[String: Any]] ?? []
+
+        func pair(_ name: String, _ version: String, _ message: String? = nil) -> [String: String] {
+            var d = ["name": name, "version": version]
+            if let message, !message.isEmpty { d["message"] = message }
+            return d
+        }
+        func baseDetails(_ status: String) -> [String: EventDetailValue] {
+            [
+                "module_status": .string(status),
+                "session_id": .string(sessionId),
+                "run_type": .string(runType),
+                "duration_seconds": .int(duration),
+            ]
+        }
+        func describe(_ list: [[String: String]], verb: String) -> String {
+            if list.count == 1, let first = list.first {
+                let version = first["version"] ?? ""
+                return version.isEmpty ? "\(first["name"] ?? "Unknown") \(verb)" : "\(first["name"] ?? "Unknown") \(version) \(verb)"
+            }
+            return "\(list.count) packages \(verb)"
+        }
+
+        // Successes per action, from the install events of this session.
+        var installed: [[String: String]] = []
+        var updated: [[String: String]] = []
+        var removed: [[String: String]] = []
+        var failed: [[String: String]] = []
+        var seen = Set<String>()
+        for event in sessionEvents where (event["eventType"] as? String) == "install" {
+            let name = event["package"] as? String ?? ""
+            let version = event["version"] as? String ?? ""
+            let action = event["action"] as? String ?? ""
+            let status = event["status"] as? String ?? ""
+            guard !name.isEmpty, seen.insert("\(action)|\(name)|\(status)").inserted else { continue }
+            switch (action, status) {
+            case ("install", "completed"):
+                // Munki has no separate update action; an install event whose target
+                // version differs from what the report says was installed before is an update.
+                let wasUpdate = (event["installedVersion"] as? String).map { !$0.isEmpty && $0 != version } ?? false
+                if wasUpdate { updated.append(pair(name, version)) } else { installed.append(pair(name, version)) }
+            case ("uninstall", "completed"):
+                removed.append(pair(name, version))
+            case (_, "failed"):
+                failed.append(pair(name, version, event["error"] as? String ?? event["message"] as? String))
+            default:
+                break
+            }
+        }
+        for (list, action, verb) in [(installed, "install", "installed"), (updated, "update", "updated"), (removed, "remove", "removed")] where !list.isEmpty {
+            var details = baseDetails("success")
+            details["action"] = .string(action)
+            details["count"] = .int(list.count)
+            details["items"] = .dictArray(list)
+            events.append(ReportMateEvent(moduleId: "installs", eventType: "success", message: describe(list, verb: verb), timestamp: Date(), details: details))
+        }
+
+        // Errors: items that errored plus run-level errors with a name.
+        var failedNames = Set(failed.compactMap { $0["name"] })
+        for item in items where (item["currentStatus"] as? String) == "Error" {
+            let name = item["name"] as? String ?? ""
+            guard !name.isEmpty, failedNames.insert(name).inserted else { continue }
+            failed.append(pair(name, item["version"] as? String ?? "", item["lastError"] as? String))
+        }
+        var operationalErrors: [[String: String]] = []
+        for problem in errorItems {
+            let message = problem["message"] as? String ?? ""
+            if let name = problem["name"] as? String, !name.isEmpty {
+                if failedNames.insert(name).inserted { failed.append(pair(name, problem["version"] as? String ?? "", message)) }
+            } else if !message.isEmpty {
+                operationalErrors.append(["message": message])
+            }
+        }
+        if !failed.isEmpty || !operationalErrors.isEmpty {
+            var details = baseDetails("error")
+            details["count"] = .int(failed.count + operationalErrors.count)
+            if !failed.isEmpty { details["failed_items"] = .dictArray(failed) }
+            if !operationalErrors.isEmpty { details["operational_errors"] = .dictArray(operationalErrors) }
+            let message = failed.isEmpty
+                ? "\(operationalErrors.count) Munki error\(operationalErrors.count == 1 ? "" : "s")"
+                : (failed.count == 1 ? "\(failed[0]["name"] ?? "Unknown") \(failed[0]["version"] ?? "") failed to install".replacingOccurrences(of: "  ", with: " ") : "\(failed.count) failed installs")
+            events.append(ReportMateEvent(moduleId: "installs", eventType: "error", message: message, timestamp: Date(), details: details))
+        }
+
+        // Warnings: attributed ones become warning_items, the rest operational_warnings.
+        var warnings: [[String: String]] = []
+        var operationalWarnings: [[String: String]] = []
+        var warnedNames = Set<String>()
+        for problem in warningItems {
+            let message = problem["message"] as? String ?? ""
+            if let name = problem["name"] as? String, !name.isEmpty {
+                guard !failedNames.contains(name), warnedNames.insert(name).inserted else { continue }
+                warnings.append(pair(name, problem["version"] as? String ?? "", message))
+            } else if !message.isEmpty {
+                operationalWarnings.append(["message": message, "action": "", "event_type": "warning"])
+            }
+        }
+        if !warnings.isEmpty || !operationalWarnings.isEmpty {
+            var details = baseDetails("warning")
+            details["item_warning_count"] = .int(warnings.count)
+            details["operational_warning_count"] = .int(operationalWarnings.count)
+            if !warnings.isEmpty { details["warning_items"] = .dictArray(warnings) }
+            if !operationalWarnings.isEmpty { details["operational_warnings"] = .dictArray(operationalWarnings) }
+            let message = warnings.count == 1 && operationalWarnings.isEmpty
+                ? "\(warnings[0]["name"] ?? "Unknown") warning"
+                : "\(warnings.count + operationalWarnings.count) warning\(warnings.count + operationalWarnings.count == 1 ? "" : "s")"
+            events.append(ReportMateEvent(moduleId: "installs", eventType: "warning", message: message, timestamp: Date(), details: details))
+        }
+
+        return events
+    }
+
     private func parseMessagesFromString(_ input: String) -> [String] {
         guard !input.isEmpty else { return [] }
         return input


### PR DESCRIPTION
Closes #64

Newer Munki builds write structured session reports beside `ManagedInstallReport.plist`:

```
logs/YYYY-MM-DD/HHMM/{session.json, events.jsonl, run.log, install.log}
reports/{sessions.json, events.json, items.json, run.log}
```

`MunkiSessionReportReader` reads them when `reports/sessions.json` exists and the legacy plist path is untouched otherwise, so older Munki keeps reporting exactly as before. The latest finished session is used (one still marked `running` is skipped); `events.jsonl` falls back to `reports/events.json`; `reports/run.log` replaces the log slicing.

The `munki` payload keeps every existing key and gains the names the Windows client already sends for Cimian: `sessions` (snake_case, as written), `events`, `totalSessions`, `sessionId`, `runType`, `durationSeconds`, `lastSessionStatus`, `warningItems`, `errorItems`, and per item `currentStatus`, `mappedStatus`, `latestVersion`, `lastSeenInSession`, `lastAttemptTime`, `lastAttemptStatus`, `lastUpdate`, `failureCount`, `warningCount`, `actionPerformed`. `lastError` / `lastWarning` come from the report by exact item name; the regex attribution only runs on the legacy path.

Events for such runs use the Windows shape on module `installs`: a success event per action with `items`, an error event with `failed_items`, a warning event with `warning_items` and `operational_warnings` — every item carrying its `message`, which is what lets the dashboard show the text under the item.

Also fixes `newlyRemovedItems`, which was computed but never written into the payload, so the removal event could not fire.

Verified with a debug build and `--run-modules installs --collect-only` on a Mac running the new Munki: 3 sessions, 122 events, and the run's warning attributed to its item.
