### PR TITLE
Parse YAML Munki catalogs for category enrichment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         // SQLite.swift for app usage persistence
         .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.15.4"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "5.1.0"),
     ],
     targets: [
         .target(
@@ -53,6 +54,7 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "SQLite", package: "SQLite.swift"),
+                .product(name: "Yams", package: "Yams"),
             ],
             path: "Sources",
             exclude: ["Watcher", "App", "ReportMateXPC", "Helper"],

--- a/Sources/DataCollection/Modules/InstallsModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/InstallsModuleProcessor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Yams
 
 /// Installs module processor - uses osquery first with bash fallback
 /// Supports both Munki (macOS) and Cimian (cross-platform) managed installs
@@ -1105,7 +1106,8 @@ public class InstallsModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
     /// Munki catalogs are root-level arrays of pkgsinfo dicts and can be 10-50 MB;
     /// shell-based approaches (PlistBuddy loops, plutil | JSON pipe) are too slow.
     private func collectCatalogMetadata() async throws -> [String: (category: String, developer: String)] {
-        let catalogsPath = "/Library/Managed Installs/catalogs"
+        // Overridable so the parser can be exercised against arbitrary catalogs.
+        let catalogsPath = ProcessInfo.processInfo.environment["REPORTMATE_CATALOGS_DIR"] ?? "/Library/Managed Installs/catalogs"
         var metadata: [String: (category: String, developer: String)] = [:]
         
         guard FileManager.default.fileExists(atPath: catalogsPath),
@@ -1119,9 +1121,17 @@ public class InstallsModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             let catalogPath = "\(catalogsPath)/\(catalogFile)"
             let url = URL(fileURLWithPath: catalogPath)
             
-            guard let data = try? Data(contentsOf: url),
-                  let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
-                  let items = plist as? [[String: Any]] else {
+            // Munki repos carry catalogs as plist or YAML; the on-disk copy keeps
+            // whichever the server sent, so accept both.
+            guard let data = try? Data(contentsOf: url) else { continue }
+            var items: [[String: Any]] = []
+            if let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+               let plistItems = plist as? [[String: Any]] {
+                items = plistItems
+            } else if let text = String(data: data, encoding: .utf8),
+                      let yaml = try? Yams.load(yaml: text) as? [[String: Any]] {
+                items = yaml
+            } else {
                 continue
             }
             


### PR DESCRIPTION
Closes #70

`collectCatalogMetadata` read the device's catalog copies with `PropertyListSerialization` only. A repo that serves YAML catalogs leaves the on-disk copy in YAML, the parse silently fails, and every item loses `category` / `developer` — which is why some devices' item lists lost their grouping while others (whose repo still serves plist) kept it.

The reader now falls back to Yams when the plist parse fails, and the catalogs directory is overridable with `REPORTMATE_CATALOGS_DIR` for testing. Verified as root on a managed Mac against the production YAML catalog: 219/223 items enriched.