### PR TITLE
Write a daily-rolled client log instead of relying on launchd capture

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,10 @@ let package = Package(
             name: "ReportMateXPC",
             targets: ["ReportMateXPC"]
         ),
+        .library(
+            name: "ReportMateLogging",
+            targets: ["ReportMateLogging"]
+        ),
     ],
     dependencies: [
         // Swift Argument Parser for CLI
@@ -47,9 +51,17 @@ let package = Package(
             dependencies: [],
             path: "Sources/ReportMateXPC"
         ),
+        .target(
+            name: "ReportMateLogging",
+            dependencies: [
+                .product(name: "Logging", package: "swift-log"),
+            ],
+            path: "Sources/ReportMateLogging"
+        ),
         .executableTarget(
             name: "ReportMate",
             dependencies: [
+                "ReportMateLogging",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
@@ -57,7 +69,7 @@ let package = Package(
                 .product(name: "Yams", package: "Yams"),
             ],
             path: "Sources",
-            exclude: ["Watcher", "App", "ReportMateXPC", "Helper"],
+            exclude: ["Watcher", "App", "ReportMateXPC", "Helper", "ReportMateLogging"],
             resources: [
                 .copy("Resources")
             ]
@@ -65,6 +77,7 @@ let package = Package(
         .executableTarget(
             name: "Watcher",
             dependencies: [
+                "ReportMateLogging",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "SQLite", package: "SQLite.swift"),
@@ -80,6 +93,11 @@ let package = Package(
             name: "Helper",
             dependencies: ["ReportMateXPC"],
             path: "Sources/Helper"
+        ),
+        .testTarget(
+            name: "ReportMateLoggingTests",
+            dependencies: ["ReportMateLogging"],
+            path: "Tests/ReportMateLoggingTests"
         ),
     ]
 )

--- a/Sources/ReportMateClient.swift
+++ b/Sources/ReportMateClient.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import Logging
+import ReportMateLogging
 
 /// ReportMate macOS Client - Device data collection and reporting
 @main
@@ -68,11 +69,22 @@ struct ReportMateClient: AsyncParsableCommand {
         // -vv (level 2) enables progress bars, -vvv (level 3) enables debug output
         ConsoleFormatter.setVerboseLevel(verbose)
         
-        // Configure logging
+        // Configure logging: the file is the log, the console is only what -v asks for.
+        // The file always carries INFO and up; -vvv lowers it to DEBUG.
+        let logDirectory = "/Library/Managed Reports/logs"
+        LaunchdLogTrimmer.trim(directory: logDirectory)
+        let logFile = RollingLogFile(
+            path: "\(logDirectory)/reportmate.log",
+            fallbackPath: RollingLogFile.userFallbackPath(for: "reportmate.log")
+        )
+        let fileLevel: Logger.Level = verboseLevel == .debug ? .debug : .info
         LoggingSystem.bootstrap { label in
-            var handler = StreamLogHandler.standardOutput(label: label)
-            handler.logLevel = verboseLevel.logLevel
-            return handler
+            var console = StreamLogHandler.standardOutput(label: label)
+            console.logLevel = verboseLevel.logLevel
+            return MultiplexLogHandler([
+                FileLogHandler(file: logFile, level: fileLevel),
+                console,
+            ])
         }
         
         let logger = Logger(label: "reportmate.client")

--- a/Sources/ReportMateLogging/FileLogHandler.swift
+++ b/Sources/ReportMateLogging/FileLogHandler.swift
@@ -1,0 +1,251 @@
+import Foundation
+import Logging
+
+/// swift-log handler that appends one line per record to a daily-rolled file.
+///
+/// Line format: `[yyyy-MM-dd HH:mm:ss] LEVEL message`, local time, level
+/// left-aligned in a five-character column so `INFO`/`WARN` lines carry two
+/// spaces and `DEBUG`/`ERROR` lines carry one. Every handler created for the
+/// same `RollingLogFile` shares the file and its lock, so a process with many
+/// loggers still writes one ordered stream.
+public struct FileLogHandler: LogHandler, Sendable {
+    public var logLevel: Logger.Level
+    public var metadata: Logger.Metadata = [:]
+
+    private let file: RollingLogFile
+
+    public init(file: RollingLogFile, level: Logger.Level = .info) {
+        self.file = file
+        self.logLevel = level
+    }
+
+    public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    public func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        self.file.write(level: Self.levelName(level), message: message.description)
+    }
+
+    /// Collapses swift-log's eight levels onto the four the estate convention uses.
+    public static func levelName(_ level: Logger.Level) -> String {
+        switch level {
+        case .trace, .debug: return "DEBUG"
+        case .info, .notice: return "INFO"
+        case .warning: return "WARN"
+        case .error, .critical: return "ERROR"
+        }
+    }
+}
+
+/// An append-only log file that rolls on the first write of a new local day.
+///
+/// The current file lives at `path`. When a write finds the file was last
+/// written on an earlier day it is renamed to `<stem>-yyyy-MM-dd.log` (the
+/// date of that last write) and a fresh file is started; only the newest
+/// `keep` rolled files are retained. Several processes may share the file:
+/// appends use `O_APPEND`, and the roll re-checks the file on disk before
+/// renaming so a sibling that already rolled it is not undone.
+///
+/// If the directory cannot be created or the file cannot be opened for
+/// writing (for example when running unprivileged) the file falls back to
+/// `fallbackPath` with the same rules. `path` reports where lines end up.
+public final class RollingLogFile: @unchecked Sendable {
+    public let path: String
+    public let keep: Int
+
+    private let lock = NSLock()
+    private let calendar: Calendar
+    private var descriptor: Int32 = -1
+    private var openedDay: DateComponents?
+    private let lineFormatter: DateFormatter
+    private let dayFormatter: DateFormatter
+
+    /// - Parameters:
+    ///   - path: Preferred location of the live log file.
+    ///   - fallbackPath: Used when `path` is not writable. Pass `nil` to
+    ///     disable the fallback; writes are then dropped silently.
+    ///   - keep: Number of rolled daily files to retain.
+    ///   - timeZone: Time zone that defines "the day"; local by default.
+    public init(
+        path: String,
+        fallbackPath: String? = nil,
+        keep: Int = 30,
+        timeZone: TimeZone = .current
+    ) {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        self.calendar = calendar
+        self.keep = keep
+
+        lineFormatter = DateFormatter()
+        lineFormatter.locale = Locale(identifier: "en_US_POSIX")
+        lineFormatter.timeZone = timeZone
+        lineFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+        dayFormatter = DateFormatter()
+        dayFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dayFormatter.timeZone = timeZone
+        dayFormatter.dateFormat = "yyyy-MM-dd"
+
+        if Self.prepare(path: path) {
+            self.path = path
+        } else if let fallbackPath, Self.prepare(path: fallbackPath) {
+            self.path = fallbackPath
+        } else {
+            self.path = path
+        }
+    }
+
+    deinit {
+        if descriptor >= 0 { close(descriptor) }
+    }
+
+    /// Default fallback for a file that would normally live under `/Library`.
+    public static func userFallbackPath(for path: String) -> String {
+        let name = (path as NSString).lastPathComponent
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/Library/Logs/ReportMate/\(name)"
+    }
+
+    /// Appends one formatted line, rolling the file first if the day changed.
+    public func write(level: String, message: String, at date: Date = Date()) {
+        let stamp = lock.withLock { lineFormatter.string(from: date) }
+        let paddedLevel = level.padding(toLength: max(5, level.count), withPad: " ", startingAt: 0)
+        append("[\(stamp)] \(paddedLevel) \(message)\n", at: date)
+    }
+
+    /// Appends raw text, rolling the file first if the day changed.
+    public func append(_ text: String, at date: Date = Date()) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let today = calendar.dateComponents([.year, .month, .day], from: date)
+        if descriptor < 0 || openedDay != today {
+            reopen(for: date, today: today)
+        }
+        guard descriptor >= 0 else { return }
+
+        let bytes = Array(text.utf8)
+        var offset = 0
+        while offset < bytes.count {
+            let written = bytes.withUnsafeBufferPointer {
+                Darwin.write(descriptor, $0.baseAddress! + offset, $0.count - offset)
+            }
+            if written <= 0 {
+                if errno == EINTR { continue }
+                return
+            }
+            offset += written
+        }
+    }
+
+    // MARK: - Rolling
+
+    private func reopen(for date: Date, today: DateComponents) {
+        if descriptor >= 0 {
+            close(descriptor)
+            descriptor = -1
+        }
+        rollIfStale(now: date, today: today)
+        descriptor = open(path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0o644)
+        openedDay = today
+    }
+
+    /// Renames the live file if its last write was on an earlier day than `today`.
+    private func rollIfStale(now: Date, today: DateComponents) {
+        let fm = FileManager.default
+        guard let attrs = try? fm.attributesOfItem(atPath: path),
+              let modified = attrs[.modificationDate] as? Date,
+              (attrs[.size] as? NSNumber)?.intValue ?? 0 > 0 else { return }
+
+        let lastDay = calendar.dateComponents([.year, .month, .day], from: modified)
+        guard let lastDate = calendar.date(from: lastDay),
+              let todayDate = calendar.date(from: today),
+              lastDate < todayDate else { return }
+
+        let rolled = rolledPath(for: modified)
+        if fm.fileExists(atPath: rolled) {
+            // A sibling process rolled the same day already; merge rather than clobber.
+            if let handle = FileHandle(forWritingAtPath: rolled),
+               let data = fm.contents(atPath: path) {
+                handle.seekToEndOfFile()
+                handle.write(data)
+                try? handle.close()
+                try? fm.removeItem(atPath: path)
+            }
+        } else {
+            try? fm.moveItem(atPath: path, toPath: rolled)
+        }
+        prune()
+    }
+
+    private var stem: String {
+        ((path as NSString).lastPathComponent as NSString).deletingPathExtension
+    }
+
+    private var directory: String {
+        (path as NSString).deletingLastPathComponent
+    }
+
+    private func rolledPath(for date: Date) -> String {
+        "\(directory)/\(stem)-\(dayFormatter.string(from: date)).log"
+    }
+
+    /// Deletes rolled files beyond the newest `keep`, judged by the date in the name.
+    private func prune() {
+        let fm = FileManager.default
+        guard let names = try? fm.contentsOfDirectory(atPath: directory) else { return }
+        let rolled = names.filter { Self.isRolledName($0, stem: stem) }.sorted(by: >)
+        for name in rolled.dropFirst(keep) {
+            try? fm.removeItem(atPath: "\(directory)/\(name)")
+        }
+    }
+
+    static func isRolledName(_ name: String, stem: String) -> Bool {
+        let prefix = "\(stem)-"
+        guard name.hasPrefix(prefix), name.hasSuffix(".log") else { return false }
+        let datePart = name.dropFirst(prefix.count).dropLast(4)
+        guard datePart.count == 10 else { return false }
+        for (index, character) in datePart.enumerated() {
+            if index == 4 || index == 7 {
+                if character != "-" { return false }
+            } else if !character.isNumber {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Creates the parent directory (0755) and checks the file can be appended to.
+    private static func prepare(path: String) -> Bool {
+        let directory = (path as NSString).deletingLastPathComponent
+        var isDirectory: ObjCBool = false
+        if !FileManager.default.fileExists(atPath: directory, isDirectory: &isDirectory) {
+            do {
+                try FileManager.default.createDirectory(
+                    atPath: directory,
+                    withIntermediateDirectories: true,
+                    attributes: [.posixPermissions: 0o755]
+                )
+            } catch {
+                return false
+            }
+        } else if !isDirectory.boolValue {
+            return false
+        }
+        let fd = open(path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0o644)
+        guard fd >= 0 else { return false }
+        close(fd)
+        return true
+    }
+}

--- a/Sources/ReportMateLogging/LaunchdLogTrimmer.swift
+++ b/Sources/ReportMateLogging/LaunchdLogTrimmer.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Keeps the per-daemon launchd capture files small.
+///
+/// launchd appends a daemon's stdout and stderr to
+/// `launchd-<label>.log` beside the client's own log. Those files exist so a
+/// crash leaves a trace, not as a log, so any that has grown past `limit`
+/// bytes is emptied at the next client start. Nothing rotates them.
+public enum LaunchdLogTrimmer {
+    public static let defaultLimit = 1_048_576
+
+    /// Truncates every `launchd-*.log` in `directory` larger than `limit` bytes.
+    /// Returns the names that were truncated.
+    @discardableResult
+    public static func trim(directory: String, limit: Int = defaultLimit) -> [String] {
+        let fm = FileManager.default
+        guard let names = try? fm.contentsOfDirectory(atPath: directory) else { return [] }
+        var trimmed: [String] = []
+        for name in names where name.hasPrefix("launchd-") && name.hasSuffix(".log") {
+            let path = "\(directory)/\(name)"
+            guard let attrs = try? fm.attributesOfItem(atPath: path),
+                  let size = (attrs[.size] as? NSNumber)?.intValue, size > limit else { continue }
+            if truncate(path, 0) == 0 {
+                trimmed.append(name)
+            }
+        }
+        return trimmed
+    }
+}

--- a/Sources/Watcher/main.swift
+++ b/Sources/Watcher/main.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ArgumentParser
 import Logging
+import ReportMateLogging
 import AppKit
 
 /// ReportMate Application Usage Watcher command
@@ -34,12 +35,22 @@ struct ReportMateAppUsage: ParsableCommand {
     var stats: Bool = false
     
     func run() throws {
-        // Configure logging
+        // Configure logging: the rolled file is the log. The console only carries
+        // warnings unless -v is given, so launchd's capture of stdout stays small.
         let logLevel: Logger.Level = verbose ? .debug : (quiet ? .warning : .info)
+        let logDirectory = "/Library/Managed Reports/logs"
+        LaunchdLogTrimmer.trim(directory: logDirectory)
+        let logFile = RollingLogFile(
+            path: "\(logDirectory)/reportmate-appusage.log",
+            fallbackPath: RollingLogFile.userFallbackPath(for: "reportmate-appusage.log")
+        )
         LoggingSystem.bootstrap { label in
-            var handler = StreamLogHandler.standardOutput(label: label)
-            handler.logLevel = logLevel
-            return handler
+            var console = StreamLogHandler.standardOutput(label: label)
+            console.logLevel = verbose ? .debug : .warning
+            return MultiplexLogHandler([
+                FileLogHandler(file: logFile, level: logLevel),
+                console,
+            ])
         }
         
         var logger = Logger(label: "com.reportmate.appusage")

--- a/Tests/ReportMateLoggingTests/FileLogHandlerTests.swift
+++ b/Tests/ReportMateLoggingTests/FileLogHandlerTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Logging
+import XCTest
+@testable import ReportMateLogging
+
+final class FileLogHandlerTests: XCTestCase {
+    private var directory: String!
+    private var logPath: String { "\(directory!)/reportmate.log" }
+    private let timeZone = TimeZone(identifier: "America/Vancouver")!
+
+    override func setUpWithError() throws {
+        directory = NSTemporaryDirectory() + "reportmate-logging-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: directory)
+    }
+
+    private func date(_ string: String) -> Date {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter.date(from: string)!
+    }
+
+    private func contents(_ path: String) throws -> String {
+        try String(contentsOfFile: path, encoding: .utf8)
+    }
+
+    private func setModified(_ path: String, to date: Date) throws {
+        try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: path)
+    }
+
+    func testLineFormat() throws {
+        let file = RollingLogFile(path: logPath, timeZone: timeZone)
+        let at = date("2026-03-04 05:06:07")
+        file.write(level: "INFO", message: "hello", at: at)
+        file.write(level: "WARN", message: "careful", at: at)
+        file.write(level: "DEBUG", message: "detail", at: at)
+        file.write(level: "ERROR", message: "broken", at: at)
+
+        XCTAssertEqual(try contents(logPath), """
+            [2026-03-04 05:06:07] INFO  hello
+            [2026-03-04 05:06:07] WARN  careful
+            [2026-03-04 05:06:07] DEBUG detail
+            [2026-03-04 05:06:07] ERROR broken
+
+            """)
+    }
+
+    func testHandlerCollapsesLevels() {
+        XCTAssertEqual(FileLogHandler.levelName(.trace), "DEBUG")
+        XCTAssertEqual(FileLogHandler.levelName(.debug), "DEBUG")
+        XCTAssertEqual(FileLogHandler.levelName(.info), "INFO")
+        XCTAssertEqual(FileLogHandler.levelName(.notice), "INFO")
+        XCTAssertEqual(FileLogHandler.levelName(.warning), "WARN")
+        XCTAssertEqual(FileLogHandler.levelName(.error), "ERROR")
+        XCTAssertEqual(FileLogHandler.levelName(.critical), "ERROR")
+    }
+
+    func testHandlerWritesThroughLogger() throws {
+        let file = RollingLogFile(path: logPath, timeZone: timeZone)
+        let handler = FileLogHandler(file: file, level: .info)
+        var logger = Logger(label: "test", factory: { _ in handler })
+        logger.logLevel = .info
+        logger.debug("hidden")
+        logger.info("shown")
+
+        let lines = try contents(logPath).split(separator: "\n")
+        XCTAssertEqual(lines.count, 1)
+        XCTAssertTrue(lines[0].hasSuffix("] INFO  shown"))
+    }
+
+    func testRollsOnFirstWriteOfNewDay() throws {
+        let file = RollingLogFile(path: logPath, timeZone: timeZone)
+        file.write(level: "INFO", message: "yesterday", at: date("2026-03-04 23:59:59"))
+        try setModified(logPath, to: date("2026-03-04 23:59:59"))
+
+        file.write(level: "INFO", message: "today", at: date("2026-03-05 00:00:01"))
+
+        XCTAssertEqual(try contents("\(directory!)/reportmate-2026-03-04.log"),
+                       "[2026-03-04 23:59:59] INFO  yesterday\n")
+        XCTAssertEqual(try contents(logPath), "[2026-03-05 00:00:01] INFO  today\n")
+    }
+
+    func testDoesNotRollWithinTheSameDay() throws {
+        let file = RollingLogFile(path: logPath, timeZone: timeZone)
+        file.write(level: "INFO", message: "one", at: date("2026-03-04 01:00:00"))
+        try setModified(logPath, to: date("2026-03-04 01:00:00"))
+        file.write(level: "INFO", message: "two", at: date("2026-03-04 22:00:00"))
+
+        XCTAssertEqual(try contents(logPath).split(separator: "\n").count, 2)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: "\(directory!)/reportmate-2026-03-04.log"))
+    }
+
+    func testRollUsesLastWriteDayNotYesterday() throws {
+        let file = RollingLogFile(path: logPath, timeZone: timeZone)
+        file.write(level: "INFO", message: "old", at: date("2026-03-01 12:00:00"))
+        try setModified(logPath, to: date("2026-03-01 12:00:00"))
+        file.write(level: "INFO", message: "new", at: date("2026-03-05 12:00:00"))
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: "\(directory!)/reportmate-2026-03-01.log"))
+    }
+
+    func testKeepsOnlyNewestRolledFiles() throws {
+        let fm = FileManager.default
+        for day in 1...35 {
+            let name = String(format: "reportmate-2026-01-%02d.log", day)
+            fm.createFile(atPath: "\(directory!)/\(name)", contents: Data("x\n".utf8))
+        }
+        fm.createFile(atPath: "\(directory!)/reportmate-appusage-2026-01-01.log", contents: Data("x\n".utf8))
+
+        let file = RollingLogFile(path: logPath, keep: 30, timeZone: timeZone)
+        file.write(level: "INFO", message: "old", at: date("2026-02-27 12:00:00"))
+        try setModified(logPath, to: date("2026-02-27 12:00:00"))
+        file.write(level: "INFO", message: "new", at: date("2026-02-28 12:00:00"))
+
+        let rolled = try fm.contentsOfDirectory(atPath: directory)
+            .filter { $0.hasPrefix("reportmate-2026") }
+            .sorted()
+        XCTAssertEqual(rolled.count, 30)
+        XCTAssertEqual(rolled.first, "reportmate-2026-01-07.log")
+        XCTAssertEqual(rolled.last, "reportmate-2026-02-27.log")
+        XCTAssertTrue(fm.fileExists(atPath: "\(directory!)/reportmate-appusage-2026-01-01.log"),
+                      "another stem's rolled files are left alone")
+    }
+
+    func testFallsBackWhenPrimaryIsNotWritable() throws {
+        let primary = "\(directory!)/locked/reportmate.log"
+        try FileManager.default.createDirectory(atPath: "\(directory!)/locked", withIntermediateDirectories: true,
+                                                attributes: [.posixPermissions: 0o500])
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: "\(directory!)/locked") }
+        try XCTSkipIf(geteuid() == 0, "root ignores directory permissions")
+
+        let fallback = "\(directory!)/fallback/reportmate.log"
+        let file = RollingLogFile(path: primary, fallbackPath: fallback, timeZone: timeZone)
+        file.write(level: "INFO", message: "hello", at: date("2026-03-04 05:06:07"))
+
+        XCTAssertEqual(file.path, fallback)
+        XCTAssertEqual(try contents(fallback), "[2026-03-04 05:06:07] INFO  hello\n")
+    }
+
+    func testLaunchdTrimmerTruncatesOnlyLargeCaptureFiles() throws {
+        let fm = FileManager.default
+        let big = "\(directory!)/launchd-com.example.hourly.log"
+        let small = "\(directory!)/launchd-com.example.daily.log"
+        let other = "\(directory!)/reportmate.log"
+        fm.createFile(atPath: big, contents: Data(repeating: 0x61, count: 2_048))
+        fm.createFile(atPath: small, contents: Data(repeating: 0x61, count: 512))
+        fm.createFile(atPath: other, contents: Data(repeating: 0x61, count: 2_048))
+
+        let trimmed = LaunchdLogTrimmer.trim(directory: directory, limit: 1_024)
+
+        XCTAssertEqual(trimmed, ["launchd-com.example.hourly.log"])
+        XCTAssertEqual((try fm.attributesOfItem(atPath: big))[.size] as? Int, 0)
+        XCTAssertEqual((try fm.attributesOfItem(atPath: small))[.size] as? Int, 512)
+        XCTAssertEqual((try fm.attributesOfItem(atPath: other))[.size] as? Int, 2_048)
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -801,9 +801,9 @@ EOF
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>
-    <string>/Library/Managed Reports/logs/reportmate-hourly.log</string>
+    <string>/Library/Managed Reports/logs/launchd-com.github.reportmate.hourly.log</string>
     <key>StandardErrorPath</key>
-    <string>/Library/Managed Reports/logs/reportmate-hourly.error.log</string>
+    <string>/Library/Managed Reports/logs/launchd-com.github.reportmate.hourly.log</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
@@ -840,9 +840,9 @@ EOF
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>
-    <string>/Library/Managed Reports/logs/reportmate-fourhourly.log</string>
+    <string>/Library/Managed Reports/logs/launchd-com.github.reportmate.fourhourly.log</string>
     <key>StandardErrorPath</key>
-    <string>/Library/Managed Reports/logs/reportmate-fourhourly.error.log</string>
+    <string>/Library/Managed Reports/logs/launchd-com.github.reportmate.fourhourly.log</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
@@ -890,9 +890,9 @@ EOF
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>
-    <string>/Library/Managed Reports/logs/reportmate-daily.log</string>
+    <string>/Library/Managed Reports/logs/launchd-com.github.reportmate.daily.log</string>
     <key>StandardErrorPath</key>
-    <string>/Library/Managed Reports/logs/reportmate-daily.error.log</string>
+    <string>/Library/Managed Reports/logs/launchd-com.github.reportmate.daily.log</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
@@ -938,9 +938,9 @@ EOF
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>
-    <string>/Library/Managed Reports/logs/reportmate-allmodules.log</string>
+    <string>/Library/Managed Reports/logs/launchd-com.github.reportmate.allmodules.log</string>
     <key>StandardErrorPath</key>
-    <string>/Library/Managed Reports/logs/reportmate-allmodules.error.log</string>
+    <string>/Library/Managed Reports/logs/launchd-com.github.reportmate.allmodules.log</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
@@ -976,9 +976,9 @@ EOF
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/Library/Managed Reports/logs/reportmate-appusage.log</string>
+    <string>/Library/Managed Reports/logs/launchd-com.github.reportmate.appusage.log</string>
     <key>StandardErrorPath</key>
-    <string>/Library/Managed Reports/logs/reportmate-appusage.error.log</string>
+    <string>/Library/Managed Reports/logs/launchd-com.github.reportmate.appusage.log</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
@@ -1196,6 +1196,20 @@ log_message "Starting ReportMate postinstall..."
 mkdir -p "$LOG_DIR"
 chmod 755 "$LOG_DIR"
 
+# Earlier releases let launchd append every run's stdout to these files and
+# nothing ever rotated them. The client now writes its own daily-rolled
+# reportmate.log, so the legacy files only occupy disk. Remove them once.
+for legacy in reportmate-hourly reportmate-4hourly reportmate-fourhourly reportmate-daily \
+              reportmate-allmodules reportmate-boot reportmate-firstrun \
+              munki-postflight reportmate-munki-postflight; do
+    for suffix in .log .error.log; do
+        if [ -f "${LOG_DIR}/${legacy}${suffix}" ]; then
+            log_message "Removing legacy log ${legacy}${suffix}"
+            rm -f "${LOG_DIR}/${legacy}${suffix}"
+        fi
+    done
+done
+
 # ═══════════════════════════════════════════════════════════════════════════
 # INSTALL OSQUERY IF MISSING
 # ═══════════════════════════════════════════════════════════════════════════
@@ -1411,14 +1425,35 @@ if [ -d "$MUNKI_DIR" ]; then
 RUNTYPE="${1:-}"
 POSTFLIGHT_D="/usr/local/munki/postflight.d"
 LOG_DIR="/Library/Managed Reports/logs"
-LOG="${LOG_DIR}/munki-postflight.log"
-
+LOG="${LOG_DIR}/reportmate-postflight.log"
 mkdir -p "$LOG_DIR" 2>/dev/null
-log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOG" 2>/dev/null; }
 
-log "Munki postflight started (runtype: ${RUNTYPE:-none})"
+# Same rules as the client's own log: roll on the first write of a new local
+# day to reportmate-postflight-YYYY-MM-DD.log and keep the newest 30 days.
+roll_log() {
+    [ -s "$LOG" ] || return 0
+    local last today rolled
+    last=$(/usr/bin/stat -f '%Sm' -t '%Y-%m-%d' "$LOG" 2>/dev/null) || return 0
+    today=$(date '+%Y-%m-%d')
+    [[ "$last" < "$today" ]] || return 0
+    rolled="${LOG_DIR}/reportmate-postflight-${last}.log"
+    if [ -e "$rolled" ]; then
+        cat "$LOG" >> "$rolled" 2>/dev/null && rm -f "$LOG"
+    else
+        mv "$LOG" "$rolled" 2>/dev/null
+    fi
+    ls -1 "${LOG_DIR}"/reportmate-postflight-????-??-??.log 2>/dev/null | sort -r | tail -n +31 | \
+        while IFS= read -r old; do rm -f "$old"; done
+}
+roll_log
+log() {
+    local level="$1"; shift
+    printf '[%s] %-5s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$level" "$*" >> "$LOG" 2>/dev/null
+}
+
+log INFO "Munki postflight started (runtype: ${RUNTYPE:-none})"
 if [ ! -d "$POSTFLIGHT_D" ]; then
-    log "No postflight.d directory; nothing to run"
+    log INFO "No postflight.d directory; nothing to run"
     exit 0
 fi
 
@@ -1428,23 +1463,26 @@ for script in "$POSTFLIGHT_D"/*; do
     name=$(basename "$script")
     case "$name" in .*) continue ;; esac
     if [ ! -x "$script" ]; then
-        log "Skipping non-executable: $name"
+        log WARN "Skipping non-executable: $name"
         continue
     fi
     # A copy of this wrapper inside the directory it orchestrates would recurse forever
     if grep -q "ReportMate postflight wrapper" "$script" 2>/dev/null; then
-        log "Skipping wrapper copy: $name"
+        log WARN "Skipping wrapper copy: $name"
         continue
     fi
     count=$((count + 1))
-    log "Running: $name"
-    if "$script" "$RUNTYPE" >> "$LOG" 2>&1; then
-        log "  $name completed successfully"
+    log INFO "Running: $name"
+    # Child output is folded into this log line by line so one grammar survives.
+    "$script" "$RUNTYPE" 2>&1 | while IFS= read -r line; do log INFO "  $name: $line"; done
+    rc=${PIPESTATUS[0]}
+    if [ "$rc" -eq 0 ]; then
+        log INFO "  $name completed successfully"
     else
-        log "  $name exited $? (continuing)"
+        log ERROR "  $name exited $rc (continuing)"
     fi
 done
-log "Munki postflight completed ($count script(s))"
+log INFO "Munki postflight completed ($count script(s))"
 exit 0
 WRAPPER_EOF
     chmod 755 "$POSTFLIGHT"
@@ -1464,19 +1502,22 @@ WRAPPER_EOF
 RUNNER="/Applications/Utilities/Managed Reports Runner.app/Contents/MacOS/managedreportsrunner"
 [ -x "$RUNNER" ] || RUNNER="/usr/local/reportmate/managedreportsrunner"
 LOG_DIR="/Library/Managed Reports/logs"
-LOG="${LOG_DIR}/reportmate-munki-postflight.log"
+LOG="${LOG_DIR}/reportmate-postflight.log"
 mkdir -p "$LOG_DIR" 2>/dev/null
-stamp() { date '+%Y-%m-%d %H:%M:%S'; }
+log() {
+    local level="$1"; shift
+    printf '[%s] %-5s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$level" "$*" >> "$LOG" 2>/dev/null
+}
 
-echo "[$(stamp)] Munki run finished (runtype: ${1:-none}); collecting installs" >> "$LOG"
+log INFO "Munki run finished (runtype: ${1:-none}); collecting installs"
 if [ -x "$RUNNER" ]; then
     # Munki gives a postflight 60 seconds; collecting and transmitting the installs
     # module can take longer on a big manifest, so run it detached and return at
-    # once. The module writes its own log; this one records the hand-off.
-    nohup /bin/sh -c '"$0" --run-modules installs >> "$1" 2>&1; echo "[$(date "+%Y-%m-%d %H:%M:%S")] installs module exited $?" >> "$1"' "$RUNNER" "$LOG" >/dev/null 2>&1 &
-    echo "[$(stamp)] installs module started in the background (pid $!)" >> "$LOG"
+    # once. The client writes its own reportmate.log; this one records the hand-off.
+    nohup /bin/sh -c '"$0" --run-modules installs >/dev/null 2>&1; rc=$?; printf "[%s] %-5s %s\n" "$(date "+%Y-%m-%d %H:%M:%S")" INFO "installs module exited $rc" >> "$1"' "$RUNNER" "$LOG" >/dev/null 2>&1 &
+    log INFO "installs module started in the background (pid $!)"
 else
-    echo "[$(stamp)] managedreportsrunner not found; skipping" >> "$LOG"
+    log ERROR "managedreportsrunner not found; skipping"
 fi
 exit 0
 REPORTMATE_EOF
@@ -1508,10 +1549,11 @@ plist_set_if_missing ValidateSSL -bool true
 plist_set_if_missing Timeout -integer 300
 plist_set_if_missing EnabledModules -array installs applications system management identity hardware peripherals security network inventory
 
-# Run initial collection immediately so the device appears in ReportMate right away
+# Run initial collection immediately so the device appears in ReportMate right away.
+# The client writes its own log; nothing here needs capturing.
 log_message "Running initial inventory and system collection..."
 nohup /usr/local/reportmate/managedreportsrunner --run-modules inventory,system \
-    >> "$LOG_DIR/reportmate-firstrun.log" 2>&1 &
+    >/dev/null 2>&1 &
 disown
 
 log_message "ReportMate postinstall complete."

--- a/docs/MUNKI_INTEGRATION.md
+++ b/docs/MUNKI_INTEGRATION.md
@@ -81,7 +81,7 @@ graph TD
 - Runs executable scripts in alphanumeric order
 - Skips hidden files (`.dotfiles`)
 - Passes `$RUNTYPE` argument to each script
-- Logs execution to `/Library/Managed Reports/logs/munki-postflight.log`
+- Logs execution to `/Library/Managed Reports/logs/reportmate-postflight.log`, rolled daily with the newest 30 days kept
 - Non-blocking: failure in one script doesn't prevent others from running
 
 **Source:** Emitted by the package postinstall (see `build.sh`), so a reinstall always recreates it.
@@ -158,19 +158,20 @@ head -5 /usr/local/munki/postflight
 sudo /usr/local/munki/postflight auto
 
 # Check logs
-tail -50 /Library/Managed Reports/logs/munki-postflight.log
-tail -50 /Library/Managed Reports/logs/reportmate-munki-postflight.log
+tail -50 /Library/Managed Reports/logs/reportmate-postflight.log
+tail -50 /Library/Managed Reports/logs/reportmate.log
 ```
 
 **Expected log output:**
 ```
-[2026-01-22 11:30:00] Munki postflight started (runtype: auto)
-[2026-01-22 11:30:00] Found 2 script(s) in postflight.d
-[2026-01-22 11:30:00] Running: 00-original.sh
-[2026-01-22 11:30:03]   00-original.sh completed successfully
-[2026-01-22 11:30:03] Running: reportmate.sh
-[2026-01-22 11:30:08]   reportmate.sh completed successfully
-[2026-01-22 11:30:08] Munki postflight completed
+[2026-01-22 11:30:00] INFO  Munki postflight started (runtype: auto)
+[2026-01-22 11:30:00] INFO  Running: munkireport.sh
+[2026-01-22 11:30:03] INFO    munkireport.sh completed successfully
+[2026-01-22 11:30:03] INFO  Running: reportmate.sh
+[2026-01-22 11:30:03] INFO  Munki run finished (runtype: auto); collecting installs
+[2026-01-22 11:30:03] INFO  installs module started in the background (pid 4242)
+[2026-01-22 11:30:03] INFO    reportmate.sh completed successfully
+[2026-01-22 11:30:03] INFO  Munki postflight completed (2 script(s))
 ```
 
 ### Verify Data Submission
@@ -259,7 +260,7 @@ sudo chown root:wheel /usr/local/munki/postflight
 **Diagnosis:**
 ```bash
 # Check execution time in logs
-grep "completed" /Library/Managed Reports/logs/munki-postflight.log
+grep "completed" /Library/Managed Reports/logs/reportmate-postflight.log
 ```
 
 **Tuning:**


### PR DESCRIPTION
## Summary

The client only logged through `StreamLogHandler.standardOutput`, so the files under `/Library/Managed Reports/logs` were launchd's raw capture of each daemon's stdout and stderr. Nothing rotated them, three line grammars shared one file, and on long-lived installs they grew to multiple gigabytes.

This adds a `ReportMateLogging` library target (swift-log only, no new external dependencies) and moves the client to writing its own log.

## Changes

- `FileLogHandler` + `RollingLogFile`: appends `[yyyy-MM-dd HH:mm:ss] LEVEL message` in local time, level left-aligned in a five-character column (`INFO  `, `WARN  `, `DEBUG `, `ERROR `). swift-log trace/debug map to DEBUG, info/notice to INFO, warning to WARN, error/critical to ERROR. On the first write of a new local day the file is renamed to `<stem>-yyyy-MM-dd.log` (the date of its last write) and the newest 30 rolled files are kept. Creates the directory 0755 if missing; falls back to `~/Library/Logs/ReportMate/<name>` when the primary path is not writable. Appends use `O_APPEND` and the roll re-checks the file on disk, so concurrent daemons sharing `reportmate.log` do not undo each other's roll.
- CLI (`managedreportsrunner`) writes `/Library/Managed Reports/logs/reportmate.log` (INFO and up; `-vvv` lowers it to DEBUG), multiplexed with the existing console handler so `-v` output is unchanged.
- App usage watcher writes `reportmate-appusage.log` with the same rules; its console handler only carries warnings unless `-v` so launchd's capture stays small.
- `LaunchdLogTrimmer`: on each client and watcher start, any `launchd-*.log` over 1 MB is truncated.
- `build.sh` LaunchDaemon plists: `StandardOutPath` and `StandardErrorPath` both point at `launchd-<label>.log`, one small file per daemon.
- Munki postflight wrapper and `reportmate.sh`: log to `reportmate-postflight.log` in the same format with the same daily roll and 30-day retention, done in bash; child script output is folded in line by line so one grammar survives. The detached installs run no longer appends the runner's stdout to the postflight log.
- Package postinstall removes the legacy unbounded capture files (`reportmate-hourly`, `reportmate-4hourly`, `reportmate-fourhourly`, `reportmate-daily`, `reportmate-allmodules`, `reportmate-boot`, `reportmate-firstrun`, `munki-postflight`, `reportmate-munki-postflight`, plus their `.error.log` twins) and no longer redirects the first run into a file.
- `docs/MUNKI_INTEGRATION.md` updated for the new log file and format.

`LogFileStore` in the GUI lists every `.log` in the directory, so the rolled files and `launchd-*.log` show up without changes.

## Verification

- `swift build --product managedreportsrunner` and `swift build --product reportmate-appusage` succeed.
- New `ReportMateLoggingTests` target: 9 tests pass covering the line format, level mapping, logger integration, the daily roll (including a multi-day gap), 30-file retention scoped to the stem, the unprivileged fallback, and the launchd trimmer, all against a temporary directory.
- The rewritten postflight wrapper was exercised against a temporary directory: a stale live file rolled to its last-write date, retention pruned to 30, and child output landed in the new grammar.
- Not verified on a real install: the LaunchDaemon plist change, the postinstall cleanup and the postflight scripts as deployed by the package.
