### PR TITLE
Never skip an explicitly requested module run for a recent cache

### DIFF
--- a/Sources/Core/ReportMateCore.swift
+++ b/Sources/Core/ReportMateCore.swift
@@ -72,8 +72,11 @@ public class ReportMateCore {
                 // Normal collection mode
                 
                 // Check if we should skip collection due to recent cache
+                // An explicit module list is a deliberate request (the Munki
+                // postflight asking for installs), not a scheduled sweep, so it
+                // is never traded away for a cache the hourly daemon just wrote.
                 let shouldSkip = await shouldSkipCollection()
-                if !force && shouldSkip && !collectOnly {
+                if !force && shouldSkip && !collectOnly && modulesToRun == nil {
                     logger.info("Skipping collection - recent cache available")
                     return .success(CollectionSummary(moduleCount: 0, recordCount: 0, cached: true))
                 }

--- a/build.sh
+++ b/build.sh
@@ -1514,7 +1514,7 @@ if [ -x "$RUNNER" ]; then
     # Munki gives a postflight 60 seconds; collecting and transmitting the installs
     # module can take longer on a big manifest, so run it detached and return at
     # once. The client writes its own reportmate.log; this one records the hand-off.
-    nohup /bin/sh -c '"$0" --run-modules installs >/dev/null 2>&1; rc=$?; printf "[%s] %-5s %s\n" "$(date "+%Y-%m-%d %H:%M:%S")" INFO "installs module exited $rc" >> "$1"' "$RUNNER" "$LOG" >/dev/null 2>&1 &
+    nohup /bin/sh -c '"$0" --run-modules installs --force >/dev/null 2>&1; rc=$?; printf "[%s] %-5s %s\n" "$(date "+%Y-%m-%d %H:%M:%S")" INFO "installs module exited $rc" >> "$1"' "$RUNNER" "$LOG" >/dev/null 2>&1 &
     log INFO "installs module started in the background (pid $!)"
 else
     log ERROR "managedreportsrunner not found; skipping"


### PR DESCRIPTION
shouldSkipCollection() returned true for any non-forced run within CollectionInterval of the last transmission. The hourly daemon refreshes that timestamp every hour, so the Munki postflight's --run-modules installs run was skipped as 'recent cache available' on almost every Munki run, exited 0, and the installs module went stale for days while every other module stayed current. An explicit --run-modules list now bypasses the cache check, and the postflight passes --force as well.