### PR TITLE
Read a session's failure count when its summary has no errors field

### DIFF
--- a/Sources/DataCollection/Services/ManagedLogSurvey.swift
+++ b/Sources/DataCollection/Services/ManagedLogSurvey.swift
@@ -265,7 +265,10 @@ public enum ManagedLogSurvey {
             return nil
         }
         let summary = json["summary"] as? [String: Any]
+        // The Munki fork's summary carries errors and warnings; Cimian's and
+        // StartSet's carry failures (and no warning count), so fall back to it.
         var errors = (summary?["errors"] as? NSNumber)?.intValue
+            ?? (summary?["failures"] as? NSNumber)?.intValue
         var warnings = (summary?["warnings"] as? NSNumber)?.intValue
         if errors == nil, let items = json["error_items"] as? [Any] { errors = items.count }
         if warnings == nil, let items = json["warning_items"] as? [Any] { warnings = items.count }


### PR DESCRIPTION
Cimian's and StartSet's `session.json` summaries carry `failures` and no warning count, while the Munki fork's carry `errors` and `warnings`. The survey now falls back to `failures` for the error count so the latest-run badge is populated on both platforms.