### PR TITLE
Send a removal's packages as removed_items, not a flat map

### DIFF
--- a/Sources/ReportMateClient.swift
+++ b/Sources/ReportMateClient.swift
@@ -835,17 +835,24 @@ struct ReportMateClient: AsyncParsableCommand {
             } else {
                 message = "\(newlyRemovedItems.count) packages removed"
             }
+            // A removal goes out as `removed_items`, not as a flat name -> version map:
+            // Munki reports no version for a removal, and an empty value in a flat map
+            // is indistinguishable from context, so the dashboard dropped every entry
+            // and rendered "2 packages removed" with nothing under it. `action` also
+            // keeps it from being coloured and labelled as an install.
             events.append(ReportMateEvent(
                 moduleId: "managedinstalls",
                 eventType: "success",
                 message: message,
                 timestamp: Date(),
-                stringDetails: newlyRemovedItems.count <= 5
-                    ? Dictionary(uniqueKeysWithValues: newlyRemovedItems.compactMap { item -> (String, String)? in
+                details: [
+                    "action": .string("remove"),
+                    "count": .int(newlyRemovedItems.count),
+                    "removed_items": .dictArray(newlyRemovedItems.compactMap { item -> [String: String]? in
                         guard let name = item["name"] else { return nil }
-                        return (name, item["version"] ?? "")
-                      })
-                    : ["count": String(newlyRemovedItems.count)]
+                        return ["name": name, "version": item["version"] ?? ""]
+                    }),
+                ]
             ))
         }
         
@@ -942,7 +949,9 @@ struct ReportMateClient: AsyncParsableCommand {
             var details = baseDetails("success")
             details["action"] = .string(action)
             details["count"] = .int(list.count)
-            details["items"] = .dictArray(list)
+            // Removals go under their own key so the dashboard labels them "Removed"
+            // rather than folding them in with the installs.
+            details[action == "remove" ? "removed_items" : "items"] = .dictArray(list)
             events.append(ReportMateEvent(moduleId: "installs", eventType: "success", message: describe(list, verb: verb), timestamp: Date(), details: details))
         }
 


### PR DESCRIPTION
A Munki removal event went out as a flat `name -> version` map. Munki reports no version for a removal, so every value was empty, and the dashboard could not tell those pairs apart from context fields — "2 packages removed" expanded to "No further detail was reported for this event". The map was also capped at five items, so a larger removal sent only a count.

Both the legacy report path and the session-report path now send `removed_items` with `action: "remove"` and the full list, so a removal is labelled and coloured as a removal instead of being folded in with the installs.

Paired with reportmate/reportmate-app-web, which also fixes the rendering for clients already in the field, and emilycarru-its-infra/munki#36, which puts the uninstalled version into `RemovalResults` so a removed package stops reporting "Unknown".

Verified with `./build.sh --debug --skip-pkg --skip-zip --skip-dmg`.