### PR TITLE
Rewrite the README against the current agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **macadmins osquery extension** (additional macOS-specific tables)
 - **Bash** (shell commands as fallback for data collection)
 
-Any new code or modifications MUST use these technologies only. The legacy `PythonService.swift` exists but should not be extended or used for new functionality.
+Any new code or modifications MUST use these technologies only. No Python remains in the tree; do not reintroduce it.
 
 ### Example: Use `jq` NOT Python for JSON Processing
 
@@ -83,9 +83,6 @@ sudo .build/release/managedreportsrunner --run-module security
 # Run multiple modules
 sudo .build/release/managedreportsrunner --run-modules security,network,hardware
 
-# Test configuration
-sudo .build/release/managedreportsrunner --test
-
 # Collect only (no transmission)
 sudo .build/release/managedreportsrunner --collect-only
 ```
@@ -104,7 +101,7 @@ Sources/
 │   ├── Services/
 │   │   ├── APIClient.swift      # HTTP client for ReportMate API
 │   │   ├── BashService.swift    # Shell command execution
-│   │   └── PythonService.swift  # LEGACY - do not use or extend
+│   │   └── ProcessRunner.swift  # Process execution with timeouts
 │   └── Utils/                   # SystemUtils for device info
 ├── DataCollection/
 │   ├── DataCollectionService.swift  # Coordinates module execution
@@ -132,7 +129,7 @@ Sources/
 1. `ReportMateClient` parses CLI args, initializes `ConfigurationManager`
 2. `ConfigurationManager` loads settings: defaults → plist → environment → CLI args
 3. For each enabled module, creates a `ModuleProcessor` subclass
-4. `ModuleProcessor.executeWithFallback()` tries: osquery → bash (no Python for new code)
+4. `ModuleProcessor.executeWithFallback()` tries: osquery → bash
 5. Results aggregated into `UnifiedDevicePayload` matching Windows client format
 6. `APIClient` transmits to ReportMate API
 
@@ -140,15 +137,16 @@ Sources/
 
 Each module processor extends `BaseModuleProcessor` and implements `collectData()`. The base class provides `executeWithFallback(osquery:bash:)` - use only osquery and bash for data collection.
 
-Available modules: `hardware`, `system`, `network`, `security`, `applications`, `management`, `inventory`, `displays`, `printers`, `peripherals`, `installs`, `profiles`
+Available modules: `hardware`, `system`, `network`, `security`, `applications`, `management`, `inventory`, `identity`, `peripherals`, `installs`. `displays` and `printers` are accepted as aliases of `peripherals`.
 
 ### Configuration Hierarchy (highest to lowest precedence)
 
 1. Command-line arguments
 2. Environment variables (`REPORTMATE_*` prefix)
-3. System plist (`/Library/Application Support/ReportMate/reportmate.plist`)
-4. User plist (`~/Library/Application Support/ReportMate/reportmate.plist`)
-5. Embedded defaults
+3. Managed preferences from an MDM configuration profile (`com.github.reportmate`)
+4. System plist (`/Library/Preferences/com.github.reportmate.plist`)
+5. User plist (`~/Library/Managed Reports/reportmate.plist`)
+6. Embedded defaults
 
 ## Key Dependencies
 
@@ -169,10 +167,12 @@ Available modules: `hardware`, `system`, `network`, `security`, `applications`, 
 ## LaunchDaemons
 
 The installer creates multiple daemons with different schedules:
-- `com.github.reportmate.boot` - Full collection at boot
-- `com.github.reportmate.hourly` - security, profiles, network, management
-- `com.github.reportmate.fourhourly` - applications, inventory, system
-- `com.github.reportmate.daily` - hardware, displays (random offset within the hour after 09:00)
+- `com.github.reportmate.hourly` - security, network, management, hardware (quick storage mode)
+- `com.github.reportmate.fourhourly` - applications, inventory, system, identity, peripherals
+- `com.github.reportmate.daily` - hardware with deep storage analysis (random offset within the hour after 09:00)
+- `com.github.reportmate.allmodules` - full collection, random offset in the 04:00-06:00 window
+- `com.github.reportmate.installs` - installs module, no schedule; kickstarted by the Munki postflight
+- `com.github.reportmate.appusage` - the persistent app usage watcher (RunAtLoad + KeepAlive)
 
 ## Worktrees
 

--- a/README.md
+++ b/README.md
@@ -1,535 +1,161 @@
 # ReportMate macOS Client
 
-ReportMate Client-side macOS application for gathering endpoint telemetry for monitoring dashboard using `osquery`.
+Native macOS endpoint agent for ReportMate. It collects device telemetry —
+hardware, system, security, network, identity, applications, managed installs,
+MDM state and peripherals — and POSTs it to the ReportMate API as a single JSON
+payload.
 
-Written in Swift 6.2. Designed to run as a native macOS binary with async/await and modern concurrency. It collects detailed device information using `osquery` with bash and Python fallbacks, and securely transmits it to the ReportMate API.
+Written in Swift (Swift tools 6.0, `.macOS(.v14)`) and built with Swift Package
+Manager. Data comes from osquery and the macadmins osquery extension where a
+table exists, and from `system_profiler`, `ioreg`, `dscl`, `profiles` and other
+command-line tools where it does not, so a Mac without osquery still reports.
 
-## Quick Start
+Full documentation lives in the
+[wiki](https://github.com/reportmate/reportmate-client-mac/wiki).
 
-### Prerequisites
+## Install
 
-- macOS 14.0+ (Sonoma)
-- Xcode 15.0+ with Swift 6.2
-- Swift Package Manager
-- osquery (recommended via Homebrew: `brew install osquery`)
+Releases publish an **unsigned** `ReportMate-<version>.pkg`. Sign and notarize
+it with your own Developer ID before deploying it to managed Macs; the release
+notes on each release carry the exact `codesign` / `productsign` / `notarytool`
+invocations.
 
-### Quick Build
-
-```bash
-# Simple build
-make build
-
-# Release build
-make release
-
-# Create distribution packages
-make package
-
-# Build and code sign
-make sign
-```
-
-### Building ReportMate
-
-The project uses Swift Package Manager with automated build scripts:
+Install it the usual way.
 
 ```bash
-# Simple build
-./build.sh
-
-# Build specific version  
-./build.sh --version "2024.06.27"
-
-# Clean build for release
-./build.sh --clean --version "2024.06.27" --api-url "https://api.reportmate.com" --sign
+sudo installer -pkg ReportMate-<version>.pkg -target /
 ```
 
-### Detailed Build Process
+The postinstall installs osquery 5.21.0 from the upstream GitHub release if
+`/usr/local/bin/osqueryi` is missing, installs and bootstraps the LaunchDaemons,
+and adds the Munki postflight hook when `/usr/local/munki` exists. See
+[Installation](https://github.com/reportmate/reportmate-client-mac/wiki/Installation).
 
-#### Development Build
+## Configure
+
+The preference domain is `com.github.reportmate`. Settings are merged from the
+embedded defaults, then `~/Library/Managed Reports/reportmate.plist`, then
+`/Library/Preferences/com.github.reportmate.plist`, then managed preferences
+delivered by an MDM configuration profile, then `REPORTMATE_*` environment
+variables, then command-line overrides — each source winning over the ones
+before it.
+
+At minimum the agent needs an API URL.
 
 ```bash
-# Build in debug mode
-swift build
-
-# Run tests
-swift test
-
-# Install locally for testing
-make install
+sudo defaults write /Library/Preferences/com.github.reportmate ApiUrl "https://reportmate.example.com"
 ```
 
-#### Release Build
+A configuration profile in the same domain can set `ApiUrl`, `DeviceId`,
+`Passphrase`, `ApiKey`, `CollectionInterval`, `LogLevel` and `EnabledModules`.
+Every key, its default and its effect is listed in
+[Configuration](https://github.com/reportmate/reportmate-client-mac/wiki/Configuration).
+
+## Run
+
+The CLI is flag-based; there are no subcommands. It must run as root — any other
+uid exits immediately with `ERROR: You must run this as root!`. With no flags it
+runs every module in `EnabledModules` and transmits.
 
 ```bash
-# Build optimized binary
-swift build --configuration release
-
-# Create all distribution packages
-./build.sh --version "1.0.0" --sign
+sudo /usr/local/bin/managedreportsrunner --run-modules security,network -vv
 ```
 
-#### Custom Build Options
+| Flag | Effect |
+|---|---|
+| `-v`, `--verbose` | Raise verbosity; repeatable up to `-vvv` |
+| `--force` | Accepted and echoed in the run header; no other effect in the collection path |
+| `--collect-only` | Collect and cache, do not transmit |
+| `--transmit-only` | Do not collect; re-send the newest cached payload |
+| `--run-module <name>` | Run exactly one module |
+| `--run-modules <a,b,c>` | Run a comma-separated list, in the order given |
+| `--device-id <id>` | Override `DeviceId` |
+| `--api-url <url>` | Override `ApiUrl` |
+| `--storage-mode <mode>` | Override `StorageMode`: `quick`, `deep` or `auto` |
+| `--test`, `--info`, `--build` | Stubs: each prints one line and exits without doing the work its name suggests |
+| `--version`, `--help` | Build version; usage |
+
+Modules: `hardware`, `system`, `network`, `security`, `applications`,
+`management`, `inventory`, `identity`, `peripherals`, `installs`. `displays` and
+`printers` are accepted as aliases of `peripherals`. Details of each are in
+[Modules](https://github.com/reportmate/reportmate-client-mac/wiki/Modules), and
+the full flag reference — including the verbosity table — is in
+[Command Line Reference](https://github.com/reportmate/reportmate-client-mac/wiki/Command-Line-Reference).
+
+## On disk
+
+| Path | Contents |
+|---|---|
+| `/Applications/Utilities/Managed Reports Runner.app` | App bundle; `managedreportsrunner`, `ReportMateApp` and `ReportMateHelper` in `Contents/MacOS/` |
+| `/usr/local/bin/managedreportsrunner` | Symlink to the bundle's CLI |
+| `/usr/local/reportmate/managedreportsrunner` | Wrapper script that execs the bundle's CLI |
+| `/usr/local/reportmate/reportmate-appusage` | Application usage watcher |
+| `/usr/local/reportmate/macadmins_extension.ext` | Bundled macadmins osquery extension |
+| `/Library/Preferences/com.github.reportmate.plist` | System preferences |
+| `/Library/Managed Reports/logs/` | `reportmate.log`, rolled daily and kept 30 days, plus per-daemon launchd logs |
+| `/Library/Managed Reports/cache/` | Timestamped per-run payload cache, newest 24 runs kept |
+| `/Library/Managed Reports/appusage.sqlite` | Watcher database |
+
+## Schedule
+
+The installer bootstraps these LaunchDaemons.
+
+| Label | When | Modules |
+|---|---|---|
+| `com.github.reportmate.hourly` | `StartInterval` 3600 | `security,network,management,hardware` with `--storage-mode quick` |
+| `com.github.reportmate.fourhourly` | `StartInterval` 14400 | `applications,inventory,system,identity,peripherals` |
+| `com.github.reportmate.daily` | 09:00, random sleep up to 59 minutes | `hardware` with `--storage-mode deep` |
+| `com.github.reportmate.allmodules` | 04:00, random sleep up to 2 hours | All enabled modules |
+| `com.github.reportmate.installs` | No schedule; kickstarted by the Munki postflight | `installs` with `--force` |
+| `com.github.reportmate.appusage` | `RunAtLoad` + `KeepAlive` | The usage watcher, not a collection |
+
+## Privacy permissions
+
+ReportMate needs Full Disk Access, and TCC grants are not inherited by child
+processes, so `managedreportsrunner`, `osqueryi` and the macadmins extension
+each need their own. A PPPC template that grants `SystemPolicyAllFiles` and
+`SystemPolicySysAdminFiles` to all three ships at
+[`Sources/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig`](Sources/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig).
+
+Before deploying it through your MDM, replace `PayloadOrganization`, the
+top-level `PayloadIdentifier`, and the `TEAMID0000` placeholder in the code
+requirements with your own Team ID; regenerate the payload UUIDs with `uuidgen`.
+
+## Build from source
+
+Requirements: macOS 14+, the Xcode command line tools, a Swift 6 toolchain, and
+Homebrew `bash` — `build.sh` has a `#!/opt/homebrew/bin/bash` shebang and needs
+bash 5.
+
+Compile without packaging.
 
 ```bash
-# Build with specific version
-./build.sh --version "2024.06.27"
-
-# Clean build
-./build.sh --clean --version "1.0.0"
-
-# Build with API URL preset
-./build.sh --api-url "https://api.reportmate.com" --sign
-
-# Verbose build output
-./build.sh --verbose
+./build.sh --skip-pkg --skip-zip --skip-dmg
 ```
 
-**Output Packages:**
-
-The build process creates three deployment formats:
-
-1. **PKG Installer (Recommended)**
-   - File: `ReportMate-{version}.pkg`
-   - Use: Standard macOS installation via Installer.app
-   - Deployment: Double-click to install, or `sudo installer -pkg ReportMate.pkg -target /`
-
-2. **ZIP Archive**
-   - File: `ReportMate-{version}.zip`
-   - Use: Manual installation and automation
-   - Deployment: Extract and copy files to appropriate locations
-
-3. **DMG Disk Image**
-   - File: `ReportMate-{version}.dmg`
-   - Use: Distribution and manual installation
-   - Deployment: Mount DMG and run Install.sh script
-
-## Architecture
-
-ReportMate for macOS follows a modular architecture similar to the Windows client, but optimized for macOS with native Swift async/await patterns:
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                      ReportMate macOS                         │
-├─────────────────────────────────────────────────────────────────┤
-│ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ │
-│ │    Main     │ │Configuration│ │ Data        │ │   osquery   │ │
-│ │ Coordinator │ │  Manager    │ │ Collection  │ │   Service   │ │ 
-│ └─────────────┘ └─────────────┘ └─────────────┘ └─────────────┘ │
-│ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ │
-│ │     API     │ │ System Info │ │   Module    │ │   Logging   │ │
-│ │   Client    │ │   Service   │ │ Processors  │ │ & Telemetry │ │
-│ └─────────────┘ └─────────────┘ └─────────────┘ └─────────────┘ │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                     Data Collection                             │
-├─────────────────────────────────────────────────────────────────┤
-│ • System Information (system_profiler + osquery)               │
-│ • Security Status (System Extensions, Gatekeeper, FileVault)   │
-│ • Hardware Inventory (CPU, Memory, Disks, Peripherals)         │
-│ • Software Inventory (Applications, Frameworks, Homebrew)      │
-│ • Network Configuration (Interfaces, DNS, Proxies)             │
-│ • Management Information (MDM, Profiles, Certificates)         │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   ReportMate API (Azure)                       │
-├─────────────────────────────────────────────────────────────────┤
-│ • Secure HTTPS transmission                                     │
-│ • Authentication & authorization                                │
-│ • Real-time dashboard updates                                   │
-│ • Data storage & analytics                                      │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-## Installation Locations
-
-After deployment, files are organized following macOS conventions:
-
-### Standard Installation
-```
-/usr/local/reportmate/
-├── managedreportsrunner            # Main executable
-├── version.plist                   # Version information
-└── config/
-    ├── reportmate.plist           # Default configuration
-    └── osquery/
-        └── modules/               # Query modules
-
-/Library/Application Support/ReportMate/
-├── reportmate.plist               # System configuration
-├── osquery/                       # osquery configurations
-└── profiles/                      # Configuration Profile templates
-
-/Library/LaunchDaemons/
-└── com.reportmate.client.plist    # Launch daemon configuration
-```
-
-### Binaries (`/usr/local/reportmate/`)
-
-- `managedreportsrunner` - Main ReportMate executable (Swift binary)
-- `version.plist` - Build and version information
-- `config/` - Default configuration files
-
-### Working Data (`~/Library/Application Support/ReportMate/`)
-
-- `reportmate.plist` - User-specific configuration
-- `cache/` - Temporary cache files
-- `logs/` - Application logs
-
-### System Configuration (`/Library/Application Support/ReportMate/`)
-
-- `reportmate.plist` - System-wide configuration
-- `osquery/` - Modular osquery configuration directory
-  - `enabled-modules.json` - Module configuration  
-  - `modules/` - Individual module query files
-- `profiles/` - Configuration Profile templates
-
-## Key Features
-
-### Core Functionality
-
-- **Native Swift Performance**: Compiled Swift 6.2 binary with modern async/await
-- **osquery Integration**: Primary data collection via osquery with intelligent fallbacks
-- **Modular Architecture**: Individual processors for different data collection modules
-- **macOS Native**: Leverages SystemConfiguration, IOKit, and macOS frameworks
-- **Configuration Profiles**: Full support for MDM deployment via Configuration Profiles
-- **Security Hardened**: Code-signed, sandboxed where appropriate, minimal privileges
-
-### Data Collection Modules
-
-- **Hardware Module**: CPU, memory, storage, peripherals via IOKit
-- **System Module**: OS version, uptime, users, processes
-- **Network Module**: Interfaces, routing, DNS, proxies
-- **Security Module**: FileVault, Gatekeeper, System Integrity Protection
-- **Applications Module**: Installed apps, Homebrew packages, App Store apps
-- **Management Module**: MDM enrollment, Configuration Profiles, certificates
-- **Inventory Module**: Device identification, asset tags, location services
-
-### Enterprise Features
-
-- **PKG Installer**: Standard macOS installer package
-- **Configuration Profiles**: Native MDM configuration support
-- **Logging & Monitoring**: Structured logging with os_log integration
-- **Error Handling**: Comprehensive error recovery and reporting
-- **Scheduled Execution**: LaunchDaemon integration for automated runs
-
-## Installation Paths
-
-### Standard Installation
-```
-/usr/local/reportmate/
-├── managedreportsrunner            # Main executable
-├── version.plist                   # Version information
-└── config/
-    ├── reportmate.plist           # Default configuration
-    └── osquery/
-        └── modules/               # Query modules
-
-/Library/Application Support/ReportMate/
-├── reportmate.plist               # System configuration
-├── osquery/                       # osquery configurations
-└── profiles/                      # Configuration Profile templates
-
-/Library/LaunchDaemons/
-└── com.reportmate.client.plist    # Launch daemon configuration
-```
-
-## Command Line Interface
+Build the pkg, ZIP and DMG for a given version.
 
 ```bash
-# Run data collection (default action)
-/usr/local/reportmate/managedreportsrunner run [--force] [--device-id ID] [--api-url URL]
-
-# Test configuration and connectivity  
-/usr/local/reportmate/managedreportsrunner test [--verbose]
-
-# Display system information
-/usr/local/reportmate/managedreportsrunner info [--json]
-
-# Install and configure
-sudo /usr/local/reportmate/managedreportsrunner install --api-url URL [--device-id ID] [--api-key KEY]
+./build.sh --version 2026.01.15.1200
 ```
 
-## Configuration Management
-
-The application uses a configuration hierarchy optimized for macOS:
-
-1. **Command-line arguments** (highest precedence)
-2. **Environment variables** (`REPORTMATE_*`)
-3. **Configuration Profiles** (MDM-managed)
-4. **System plist** (`/Library/Application Support/ReportMate/reportmate.plist`)
-5. **User plist** (`~/Library/Application Support/ReportMate/reportmate.plist`)
-6. **Default configuration** (embedded in binary)
-
-### Configuration Profile Example
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>PayloadContent</key>
-    <array>
-        <dict>
-            <key>PayloadType</key>
-            <string>com.github.reportmate</string>
-            <key>PayloadIdentifier</key>
-            <string>com.github.reportmate.settings</string>
-            <key>PayloadUUID</key>
-            <string>12345678-1234-1234-1234-123456789012</string>
-            <key>PayloadVersion</key>
-            <integer>1</integer>
-            <key>ApiUrl</key>
-            <string>https://api.reportmate.yourdomain.com</string>
-            <key>Passphrase</key>
-            <string>your-client-passphrase</string>
-            <key>CollectionInterval</key>
-            <integer>3600</integer>
-            <key>LogLevel</key>
-            <string>info</string>
-            <key>EnabledModules</key>
-            <array>
-                <string>hardware</string>
-                <string>system</string>
-                <string>network</string>
-                <string>security</string>
-                <string>applications</string>
-                <string>management</string>
-                <string>inventory</string>
-            </array>
-        </dict>
-    </array>
-    <key>PayloadDisplayName</key>
-    <string>ReportMate Configuration</string>
-    <key>PayloadIdentifier</key>
-    <string>com.github.reportmate.config</string>
-    <key>PayloadType</key>
-    <string>Configuration</string>
-    <key>PayloadUUID</key>
-    <string>87654321-4321-4321-4321-210987654321</string>
-    <key>PayloadVersion</key>
-    <integer>1</integer>
-</dict>
-</plist>
-```
-
-## Requirements
-
-### Runtime Requirements
-- macOS 14.0+ (Sonoma)
-- Administrator privileges for full data collection
-- Network connectivity to ReportMate API
-- osquery (automatically installed if missing)
-
-### Build Requirements  
-- macOS 14.0+
-- Xcode 15.0+ with Swift 6.2
-- Swift Package Manager
-- Homebrew (for dependencies)
-
-## Building and Development
-
-### Code Signing
-
-#### Automatic Code Signing
-
-The build script automatically detects available Developer ID certificates:
+Sign and notarize a distribution build; both read identities from a `.env` file
+(see [`.env.example`](.env.example)).
 
 ```bash
-./build.sh --sign
+./build.sh --clean --sign --notarize
 ```
 
-#### Manual Code Signing
+`make build`, `make release`, `make package`, `make sign` and `make notarize`
+wrap the same script; `make test` runs `swift test`. `build.sh --help` lists
+every flag, and
+[Building and Releasing](https://github.com/reportmate/reportmate-client-mac/wiki/Building-and-Releasing)
+covers the pipeline in full.
 
-```bash
-# List available identities
-security find-identity -v -p codesigning
+CI compiles the release configuration on every push and pull request to `main`;
+it does not run tests, package, or sign. Pushing a `v*` or `YYYY.MM.DD.HHMM` tag
+builds the unsigned pkg and publishes it as a GitHub release with its SHA-256.
 
-# Sign with specific identity
-codesign --sign "Developer ID Application: Your Name" --force --options runtime build/managedreportsrunner
-```
+## License
 
-### Development Workflow
-
-#### Setup Development Environment
-
-```bash
-# Install dependencies
-make dev-setup
-
-# Format code
-make format
-
-# Lint code  
-make lint
-
-# Clone and setup
-git clone <repo-url>
-cd reportmate-client-mac
-
-# Install dependencies
-brew install osquery
-
-# Build and test
-swift build
-swift test
-
-# Create release build
-./build.sh --configuration release --sign
-```
-
-### Testing
-
-```bash
-# Run unit tests
-swift test
-make test
-
-# Integration tests  
-./test.sh --integration
-
-# Manual testing
-swift run managedreportsrunner test --verbose
-
-# Test binary directly
-.build/release/managedreportsrunner --help
-.build/release/managedreportsrunner test --verbose
-```
-
-#### Local Installation for Testing
-
-```bash
-# Install locally
-make install
-
-# Test installation
-/usr/local/reportmate/managedreportsrunner info
-```
-
-### Build Environment Variables
-
-The build process recognizes these environment variables:
-
-- `VERSION` - Override build version
-- `API_URL` - Default API endpoint for configuration
-- `CONFIGURATION` - Build configuration (debug/release)
-
-Example:
-```bash
-VERSION=1.0.0 API_URL=https://api.reportmate.com ./build.sh --sign
-```
-
-### Performance
-
-#### Build Times
-- Debug build: ~30 seconds
-- Release build: ~60 seconds  
-- Package creation: ~30 seconds
-
-#### Binary Size
-- Debug build: ~15MB
-- Release build: ~8MB
-- Compressed in ZIP: ~3MB
-
-### Troubleshooting
-
-#### Common Build Issues
-
-1. **Swift Version Mismatch**
-   ```bash
-   # Check Swift version
-   swift --version
-   # Should be 6.0+
-   ```
-
-2. **Missing Xcode Command Line Tools**
-   ```bash
-   xcode-select --install
-   ```
-
-3. **Package Dependencies**
-   ```bash
-   # Clean and rebuild packages
-   swift package clean
-   swift package resolve
-   ```
-
-#### Code Signing Issues
-
-1. **No Identity Found**
-   - Install Xcode and sign in with Apple Developer account
-   - Or create self-signed certificate for testing
-
-2. **Unsigned Binary Warnings**
-   - Use `--sign` flag during build
-   - Or manually sign after build
-
-#### Runtime Issues
-
-1. **Permission Denied**
-   ```bash
-   chmod +x /usr/local/reportmate/managedreportsrunner
-   ```
-
-2. **osquery Not Found**
-   ```bash
-   brew install osquery
-   # Or set custom path in configuration
-   ```
-
-### CI/CD Integration
-
-#### GitHub Actions Example
-
-```yaml
-name: Build ReportMate macOS Client
-
-on:
-  push:
-    tags: ['v*']
-
-jobs:
-  build:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: |
-        ./build.sh --version ${GITHUB_REF#refs/tags/v} --sign
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: ReportMate-packages
-        path: build/output/
-```
-
-### Security Considerations
-
-1. **Code Signing**: Always sign production binaries
-2. **Notarization**: Consider notarizing for wider distribution
-3. **Sandboxing**: Evaluate sandboxing requirements
-4. **Permissions**: Binary requires admin privileges for full data collection
-
-### Privacy Permissions
-
-ReportMate requires **Full Disk Access** and other privacy permissions to collect comprehensive system data. We provide a Configuration Profile (`.mobileconfig`) for easy deployment:
-
-**Permissions Granted:**
-- Full Disk Access (SystemPolicyAllFiles) - Read `/Library/`, `/System/`, `/Users/`, TCC database
-- System Policy Admin Files - MDM enrollment data, configuration profiles
-
-**For Enterprise Deployment:**
-Deploy the `ReportMate-PrivacyPermissions.mobileconfig` via your MDM solution (Jamf Pro, Intune, Workspace ONE, etc.) to automatically grant permissions across all managed devices.
-
-**Full Documentation:** See [PRIVACY_PROFILE_README.md](PRIVACY_PROFILE_README.md) for:
-- Detailed permission explanations
-- MDM deployment guides
-- Team ID configuration
-- Troubleshooting steps
-- Verification commands
-
-This project represents a complete rewrite optimized for macOS while maintaining compatibility with the ReportMate ecosystem. The build system provides a complete solution for developing, testing, and distributing the ReportMate macOS client with comprehensive tooling for code signing, packaging, and deployment.
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
The README described a CLI and a file layout this project no longer has. Every claim below was checked against the source at HEAD, not against the wiki.

## Corrections

| README said | Code says |
|---|---|
| `managedreportsrunner run \| test \| info \| install` subcommands | `ReportMateClient` is a single `AsyncParsableCommand` with flags only: `--run-module`, `--run-modules`, `--collect-only`, `--transmit-only`, `--device-id`, `--api-url`, `--storage-mode`, `-v`/`-vv`/`-vvv`. The documented subcommands do not parse. |
| `test`, `info` and an `install` command do work | `--test`, `--info` and `--build` are stubs printing one line each; there is no install command. `--force` is accepted and echoed but has no effect in the collection path. |
| Working data in `~/Library/Application Support/ReportMate` | `/Library/Managed Reports/{logs,cache,appusage.sqlite}`. Nothing reads or writes `/Library/Application Support/ReportMate`. |
| Config plists under `.../Application Support/ReportMate` | `/Library/Preferences/com.github.reportmate.plist` and `~/Library/Managed Reports/reportmate.plist`. |
| `/usr/local/reportmate/` holds the binary, `version.plist` and a `config/` + `osquery/` tree | Binaries live in `/Applications/Utilities/Managed Reports Runner.app/Contents/MacOS/`; `/usr/local/reportmate/` holds only a wrapper script, the usage watcher and the macadmins extension, with a symlink at `/usr/local/bin/managedreportsrunner`. |
| One daemon, `com.reportmate.client` | Six: `com.github.reportmate.{hourly,fourhourly,daily,allmodules,installs,appusage}`, with the intervals and module sets now in the README. No boot daemon (removed). |
| Profile payload type `com.github.reportmate` with a hand-written example | Domain is right, but only seven keys are profile-settable; the README now lists them and links the wiki for the rest. |
| Modules include `profiles`; `displays`/`printers` are separate | `identity` exists, `profiles` does not; `displays` and `printers` are aliases of `peripherals`. |
| Precedence puts profiles below env and system plist above user plist ambiguously | Documented in the actual merge order: defaults, user plist, system plist, managed preferences, `REPORTMATE_*`, CLI. |
| `./test.sh --integration`, `PRIVACY_PROFILE_README.md`, `ReportMate-PrivacyPermissions.mobileconfig` | None exist. The shipped PPPC template is `Sources/Resources/profiles/ReportMate-FullDiskAccess.mobileconfig`. |
| A GitHub Actions snippet running `./build.sh --sign` | CI compiles the release config only and does not run tests or package. Tag pushes build an unsigned pkg and publish it with its SHA-256. |
| Build times and binary sizes | Unverifiable; removed. |

Also added: build.sh's `#!/opt/homebrew/bin/bash` shebang means bash 5 is a build prerequisite, and signing/notarization identities come from `.env`.

CLAUDE.md repeated the stale daemon list and Application Support paths and pointed at a `PythonService.swift` that is no longer in the tree; corrected the same way.

Where the README would have duplicated the new wiki, it now carries a short accurate section and a link.

Documentation only — no source, build script, plist or workflow changes.

https://claude.ai/code/session_011rLe9AmZ81x5ide99HTmdy
