### PR TITLE
Drop the adopter name from the release workflow comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Builds an UNSIGNED ReportMate-<version>.pkg and publishes it as a GitHub
-# release. ECU's Apple Developer ID material is intentionally NOT held here:
+# release. Apple Developer ID signing material is intentionally NOT held here:
 # the pkg ships unsigned and is signed + notarized downstream by the Munki
 # bootstrap pipeline (Azure DevOps), mirroring how reportmate-client-win ships
 # unsigned and is signed by the Cimian pipeline.


### PR DESCRIPTION
The header comment in `.github/workflows/release.yml` named a specific adopter when explaining why Apple Developer ID material is not held in this repo. This is a public repo and the reasoning is generic, so the comment now states it without the name.

Comment text only — no workflow behaviour change.

https://claude.ai/code/session_011rLe9AmZ81x5ide99HTmdy