### PR TITLE
Always report an item's install-loop state, under both names

### DIFF
--- a/Sources/DataCollection/Modules/InstallsModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/InstallsModuleProcessor.swift
@@ -260,7 +260,13 @@ public class InstallsModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
                         i["warningMessages"] = messages
                         i["lastWarning"] = messages.joined(separator: "\n")
                     }
-                    if let loop = record["install_loop_detected"] as? Bool { i["hasInstallLoop"] = loop }
+                    // Always report the loop state, under both names Cimian uses.
+                    // Sending it only when the fork happened to set it left the
+                    // field absent from nearly every Mac item, so a dashboard
+                    // that reads it saw no Munki loops at all.
+                    let loop = record["install_loop_detected"] as? Bool ?? false
+                    i["hasInstallLoop"] = loop
+                    i["installLoopDetected"] = loop
                     if let code = record["status_reason_code"] as? String, !code.isEmpty { i["statusReasonCode"] = code }
                     if let reason = record["status_reason"] as? String, !reason.isEmpty { i["statusReason"] = reason }
                 }


### PR DESCRIPTION
The fork's LoopGuard records `install_loop_detected` on an item only when it has something to say, and this forwarded the flag only when the record carried it — so `hasInstallLoop` was absent from very nearly every Mac item rather than false. Across 876 live devices there are 41,634 Cimian items carrying the flag and 9 Munki ones.

Send it on every item, defaulting to false, and send `installLoopDetected` alongside it. Cimian writes both names and a consumer should not have to know which platform it is reading.

Verified with `swift build -c release --target ReportMate`. Note that build needs `Sources/Generated/ModuleVersions.swift`, which is gitignored and written at build time; without it the target fails with `cannot find 'ModuleVersions' in scope`, unrelated to this change.
