### PR TITLE
Read Apple silicon core counts and build the identity user list with jq

### DIFF
--- a/Sources/DataCollection/Modules/HardwareModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/HardwareModuleProcessor.swift
@@ -331,33 +331,29 @@ public class HardwareModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
                 windowsProcessor["logical_cores"] = logical
             }
             
-            // Parse performance/efficiency cores from system_profiler (format: "proc 14:10:4")
-            // This is only available on Apple Silicon
+            // Performance/efficiency cores on Apple silicon. system_profiler's
+            // number_processors reads "proc 14:10:4" (total:performance:efficiency)
+            // and, from macOS 26, "proc 14:0:10:4" with an extra tier in the
+            // middle; the last two numbers are always performance then efficiency.
+            // sysctl hw.perflevel0/1 (from the bash script) is authoritative when present.
             var parsedCores = false
             if let numberProcs = procDict["number_processors"] as? String, !numberProcs.isEmpty {
-                // Format: "proc total:performance:efficiency"
-                let pattern = "proc (\\d+):(\\d+):(\\d+)"
-                if let regex = try? NSRegularExpression(pattern: pattern),
-                   let match = regex.firstMatch(in: numberProcs, range: NSRange(numberProcs.startIndex..., in: numberProcs)) {
-                    if let totalRange = Range(match.range(at: 1), in: numberProcs),
-                       let perfRange = Range(match.range(at: 2), in: numberProcs),
-                       let effRange = Range(match.range(at: 3), in: numberProcs) {
-                        windowsProcessor["cores"] = Int(numberProcs[totalRange])
-                        windowsProcessor["performance_cores"] = Int(numberProcs[perfRange])
-                        windowsProcessor["efficiency_cores"] = Int(numberProcs[effRange])
-                        parsedCores = true
-                    }
+                let numbers = numberProcs.split(whereSeparator: { !$0.isNumber }).compactMap { Int($0) }
+                if numbers.count >= 3 {
+                    windowsProcessor["cores"] = numbers[0]
+                    windowsProcessor["performance_cores"] = numbers[numbers.count - 2]
+                    windowsProcessor["efficiency_cores"] = numbers[numbers.count - 1]
+                    parsedCores = true
                 }
             }
-            
-            // Fallback: try hw.perflevel values from bash script if system_profiler didn't work
-            if !parsedCores {
-                if let perfStr = procDict["performance_cores"] as? String, !perfStr.isEmpty, let perf = Int(perfStr) {
-                    windowsProcessor["performance_cores"] = perf
-                }
-                if let effStr = procDict["efficiency_cores"] as? String, !effStr.isEmpty, let eff = Int(effStr) {
-                    windowsProcessor["efficiency_cores"] = eff
-                }
+            let sysctlPerf = (procDict["performance_cores"] as? String).flatMap(Int.init) ?? procDict["performance_cores"] as? Int
+            let sysctlEff = (procDict["efficiency_cores"] as? String).flatMap(Int.init) ?? procDict["efficiency_cores"] as? Int
+            if let perf = sysctlPerf, let eff = sysctlEff, perf > 0 {
+                windowsProcessor["performance_cores"] = perf
+                windowsProcessor["efficiency_cores"] = eff
+            } else if !parsedCores {
+                if let perf = sysctlPerf { windowsProcessor["performance_cores"] = perf }
+                if let eff = sysctlEff { windowsProcessor["efficiency_cores"] = eff }
             }
             
             // Clean up architecture: "arm64e" -> "ARM64"
@@ -1571,7 +1567,7 @@ public class HardwareModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
         // Enhance with system_profiler data for number_processors (proc total:perf:eff format)
         // This gives us the performance/efficiency core breakdown on Apple Silicon
         let spHardwareScript = """
-            system_profiler SPHardwareDataType -json 2>/dev/null | python3 -c "import sys, json; data = json.load(sys.stdin).get('SPHardwareDataType', [{}])[0]; print(json.dumps({'number_processors': data.get('number_processors', ''), 'chip_type': data.get('chip_type', '')}))"
+            system_profiler SPHardwareDataType -json 2>/dev/null | jq -c '.SPHardwareDataType[0] | {number_processors: (.number_processors // ""), chip_type: (.chip_type // "")}'
         """
         
         if let spJson = try? await BashService.execute(spHardwareScript),

--- a/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
+++ b/Sources/DataCollection/Modules/IdentityModuleProcessor.swift
@@ -66,9 +66,6 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
             # Collect comprehensive user account data using dscl
             # Matches MunkiReport users module fields
             
-            users_json="["
-            first=true
-            
             # Get all local users with UID >= 500 (excluding system accounts)
             for user in $(dscl . -list /Users UniqueID 2>/dev/null | awk '$2 >= 500 && $2 < 65534 {print $1}'); do
                 user_path="/Users/$user"
@@ -189,45 +186,26 @@ public class IdentityModuleProcessor: BaseModuleProcessor, @unchecked Sendable {
                     is_disabled="true"
                 fi
                 
-                # Build JSON for this user
-                if [ "$first" = "true" ]; then
-                    first=false
-                else
-                    users_json="$users_json,"
-                fi
-                
-                # Escape quotes in strings
-                real_name_escaped=$(echo "$real_name" | sed 's/"/\\\\"/g')
-                password_hint_escaped=$(echo "$password_hint" | sed 's/"/\\\\"/g')
-                group_memberships_escaped=$(echo "$group_memberships" | sed 's/"/\\\\"/g')
-                
-                users_json="$users_json{"
-                users_json="$users_json\\"username\\": \\"$user\\","
-                users_json="$users_json\\"realName\\": \\"$real_name_escaped\\","
-                users_json="$users_json\\"uid\\": $uid,"
-                users_json="$users_json\\"gid\\": $gid,"
-                users_json="$users_json\\"homeDirectory\\": \\"$home_dir\\","
-                users_json="$users_json\\"shell\\": \\"$shell\\","
-                users_json="$users_json\\"uuid\\": \\"$uuid\\","
-                users_json="$users_json\\"isAdmin\\": $is_admin,"
-                users_json="$users_json\\"sshAccess\\": $ssh_access,"
-                users_json="$users_json\\"screenSharingAccess\\": $screen_sharing,"
-                users_json="$users_json\\"autoLoginEnabled\\": $auto_login,"
-                users_json="$users_json\\"passwordHint\\": \\"$password_hint_escaped\\","
-                users_json="$users_json\\"creationTime\\": \\"$creation_time\\","
-                users_json="$users_json\\"passwordLastSet\\": \\"$password_last_set\\","
-                users_json="$users_json\\"lastLogon\\": \\"$last_logon_iso\\","
-                users_json="$users_json\\"failedLoginCount\\": $failed_login_count,"
-                users_json="$users_json\\"lastFailedLogin\\": \\"$last_failed_login\\","
-                users_json="$users_json\\"linkedAppleId\\": \\"$linked_apple_id\\","
-                users_json="$users_json\\"linkedDate\\": \\"$linked_date\\","
-                users_json="$users_json\\"groupMembership\\": \\"$group_memberships_escaped\\","
-                users_json="$users_json\\"isDisabled\\": $is_disabled"
-                users_json="$users_json}"
-            done
-            
-            users_json="$users_json]"
-            echo "$users_json"
+                # One JSON object per user, built by jq so a hint, name or
+                # group list with quotes, backslashes or an empty numeric field
+                # cannot break the array (hand-built JSON lost every user when it did).
+                jq -cn \\
+                    --arg username "$user" --arg realName "$real_name" --arg uid "$uid" --arg gid "$gid" \\
+                    --arg homeDirectory "$home_dir" --arg shell "$shell" --arg uuid "$uuid" \\
+                    --argjson isAdmin "$is_admin" --argjson sshAccess "$ssh_access" \\
+                    --argjson screenSharingAccess "$screen_sharing" --argjson autoLoginEnabled "$auto_login" \\
+                    --arg passwordHint "$password_hint" --arg creationTime "$creation_time" \\
+                    --arg passwordLastSet "$password_last_set" --arg lastLogon "$last_logon_iso" \\
+                    --arg failedLoginCount "$failed_login_count" --arg lastFailedLogin "$last_failed_login" \\
+                    --arg linkedAppleId "$linked_apple_id" --arg linkedDate "$linked_date" \\
+                    --arg groupMembership "$group_memberships" --argjson isDisabled "$is_disabled" \\
+                    '{username: $username, realName: $realName, uid: ($uid | tonumber? // 0), gid: ($gid | tonumber? // 20),
+                      homeDirectory: $homeDirectory, shell: $shell, uuid: $uuid, isAdmin: $isAdmin, sshAccess: $sshAccess,
+                      screenSharingAccess: $screenSharingAccess, autoLoginEnabled: $autoLoginEnabled, passwordHint: $passwordHint,
+                      creationTime: $creationTime, passwordLastSet: $passwordLastSet, lastLogon: $lastLogon,
+                      failedLoginCount: ($failedLoginCount | tonumber? // 0), lastFailedLogin: $lastFailedLogin,
+                      linkedAppleId: $linkedAppleId, linkedDate: $linkedDate, groupMembership: $groupMembership, isDisabled: $isDisabled}'
+            done | jq -s .
         """
         
         // Only use bash script - osquery users table lacks admin status and other critical fields


### PR DESCRIPTION
Two collection fixes found by running the module readers over a real runner cache while building the fleet app (which now lives in `reportmate/reportmate-app-swift`).

- **Hardware**: Apple silicon core counts are read from the last two `number_processors` fields. macOS 26 reports `proc 14:0:10:4`, which recorded 0 performance cores and 10 efficiency cores; the sysctl `perflevel` counts win when they are non-zero. jq replaces the python3 call.
- **Identity**: the user list is built with `jq -cn --arg` per user and `jq -s .` at the end, so a quote or an empty field in one account no longer drops every user to `[]`.

The watcher, installer and daemons are unchanged.
